### PR TITLE
fix: update backtest formula for long squeeth pnl

### DIFF
--- a/packages/frontend/src/utils/pricer.ts
+++ b/packages/frontend/src/utils/pricer.ts
@@ -94,7 +94,7 @@ export async function getSqueethPNLCompounding(
     }
 
     cumulativeEthReturn += Math.log(price / preEthPrice)
-    cumulativeSqueethReturn += 2 * Math.log(price / preEthPrice) - fundingCost
+    cumulativeSqueethReturn += 2 * Math.log(price / preEthPrice) + Math.log(price / preEthPrice) ** 2 - fundingCost
     const longPNL = Math.round((Math.exp(cumulativeSqueethReturn) - 1) * 10000) / 100
     const shortPNL = Math.exp(-cumulativeSqueethReturn + cumulativeEthReturn * newCR) - 1
 


### PR DESCRIPTION
# Task:

## Description

Updated backtest formula with a reference to our [research paper](https://github.com/opynfinance/Research/blob/master/squeeth/whitepaper/Squeeth.pdf), adding missing item to the calculation

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change

The updated formula in the research paper:
![image](https://user-images.githubusercontent.com/26922518/148987531-806f9503-deb7-4993-9a2a-46f0cdbdb491.png)

