### PR TITLE
fix(wallet):  dont hardcode blocknative onboard to infura

### DIFF
--- a/packages/frontend/src/context/wallet.tsx
+++ b/packages/frontend/src/context/wallet.tsx
@@ -180,7 +180,9 @@ const WalletProvider: React.FC = ({ children }) => {
           {
             walletName: 'walletConnect',
             preferred: true,
-            infuraKey: process.env.NEXT_PUBLIC_INFURA_API_KEY,
+            rpc: {
+              [networkId]: RPC_URL,
+            },
           },
           {
             walletName: 'lattice',


### PR DESCRIPTION
# Task:

dont hardcode blocknative onboard to infura

## Description

Changing how the walletConnectOptions are passed to the blocknative onboard 
Now instead of all ways passing infura, it will respect the param use Alchemy


Fixes # (issue)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

tested locally by setting usealchemy = true 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
