### PR TITLE
comment revision: UPPER_MARK_RATIO set to 140% of index

### DIFF
--- a/packages/hardhat/contracts/core/Controller.sol
+++ b/packages/hardhat/contracts/core/Controller.sol
@@ -72,7 +72,7 @@ contract Controller is Ownable, ReentrancyGuard, IERC721Receiver {
 
     //80% of index
     uint256 internal constant LOWER_MARK_RATIO = 8e17;
-    //125% of index
+    //140% of index
     uint256 internal constant UPPER_MARK_RATIO = 140e16;
     // 10%
     uint256 internal constant LIQUIDATION_BOUNTY = 1e17;


### PR DESCRIPTION
# Task:

Comment typo

## Description

Updated comment for UPPER_MARK_RATIO const in Controller contract to reflect implemented value of 140% of index.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Document update

## How Has This Been Tested

NA

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
