### PR TITLE
Hides withdraw button for restricted users

### DIFF
--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -564,16 +564,20 @@ const Component: React.FC = () => {
             <div className={classes.overviewItem}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <Typography className={classes.overviewValue}>{vault?.collateralAmount.toFixed(4)}</Typography>
-                {vault?.shortAmount.isZero() && vault.collateralAmount.gt(0) ? (
-                  <button
-                    className={clsx(classes.withdrawBtn)}
-                    onClick={() => {
-                      updateCollateral(vault!.collateralAmount.negated().toString())
-                      removeCollat(vault!.collateralAmount)
-                    }}
-                  >
-                    WITHDRAW
-                  </button>
+                {!isRestricted ? (
+                  <>
+                    {vault?.shortAmount.isZero() && vault.collateralAmount.gt(0) ? (
+                      <button
+                        className={clsx(classes.withdrawBtn)}
+                        onClick={() => {
+                          updateCollateral(vault!.collateralAmount.negated().toString())
+                          removeCollat(vault!.collateralAmount)
+                        }}
+                      >
+                        WITHDRAW
+                      </button>
+                    ) : null}
+                  </>
                 ) : null}
               </div>
               <Typography className={classes.overviewTitle}>Collateral (ETH)</Typography>


### PR DESCRIPTION
# Task:
Hides withdraw button for restricted users
## Description

This PR hides withdraw button for restricted users

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Ensure that vault page doesn't show withdraw button for restricted user

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
