### PR TITLE
Fix: Some BigNumber in dependency arrays on long and short components, slowing down app 

### DIFF
--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -228,7 +228,7 @@ const OpenLong: React.FC<BuyProps> = ({ balance, open, setTradeCompleted, active
     setTradeAmount: setAmount,
     squeethExposure,
     inputQuoteLoading,
-    setInputQuoteLaoding,
+    setInputQuoteLoading,
     inputQuote,
     setInputType,
     quote,
@@ -299,7 +299,7 @@ const OpenLong: React.FC<BuyProps> = ({ balance, open, setTradeCompleted, active
       setInputType(InputType.SQTH)
       setAltTradeAmount(v)
     }
-    setInputQuoteLaoding(true)
+    setInputQuoteLoading(true)
   }
 
   return (
@@ -496,7 +496,7 @@ const CloseLong: React.FC<BuyProps> = ({
     quote,
     inputQuote,
     inputQuoteLoading,
-    setInputQuoteLaoding,
+    setInputQuoteLoading,
     setInputType,
     altTradeAmount: altAmountInputValue,
     setAltTradeAmount,
@@ -566,7 +566,7 @@ const CloseLong: React.FC<BuyProps> = ({
     }
 
     setSellLoading(false)
-  }, [amount, sell, squeethAllowance, squeethApprove, wSqueethBal])
+  }, [amount.toString(), squeethAllowance.toString(), wSqueethBal.toString(), sell, squeethApprove])
 
   const handleCloseDualInputUpdate = (v: string, currentInput: string) => {
     //If I'm inputting an amount of ETH position I'd like to sell to get squeeth, use getSellQuoteForETH in trade context
@@ -584,7 +584,7 @@ const CloseLong: React.FC<BuyProps> = ({
       setInputType(InputType.SQTH)
       setAmount(v)
     }
-    setInputQuoteLaoding(true)
+    setInputQuoteLoading(true)
   }
 
   return (

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -523,7 +523,7 @@ const CloseLong: React.FC<BuyProps> = ({
         setConfirmedAmount(val.amountIn.toFixed(6).toString())
       })
     }
-  }, [wSqueethBal, open])
+  }, [wSqueethBal.toString(), open])
 
   let openError: string | undefined
   let closeError: string | undefined

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -595,11 +595,8 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
 
   useEffect(() => {
     if (!shortVaults.length) return
-    console.log('minted ' + mintedDebt.toString() + ' lp ' + lpDebt.toString() + ' short ' + shortDebt.toString())
     const calculatedShort = mintedDebt.plus(lpDebt).plus(shortDebt)
-    console.log('calc short ' + calculatedShort.toString())
     const contractShort = shortVaults.length && shortVaults[firstValidVault]?.shortAmount
-    console.log(' contract short ' + shortVaults.length && shortVaults[firstValidVault]?.shortAmount.toString())
     if (calculatedShort !== contractShort) {
       setFinalShortAmount(contractShort)
     } else {

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -605,14 +605,7 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
     } else {
       setFinalShortAmount(shortDebt)
     }
-  }, [
-    shortVaults.length,
-    mintedDebt.toString(),
-    shortDebt.toString(),
-    lpDebt.toString(),
-    firstValidVault,
-    shortVaults[firstValidVault]?.shortAmount?.toString(),
-  ])
+  }, [shortVaults.length, mintedDebt.toString(), shortDebt.toString(), lpDebt.toString(), firstValidVault])
 
   useEffect(() => {
     if (!open && shortVaults.length && shortVaults[firstValidVault].shortAmount.lt(amount)) {

--- a/packages/frontend/src/context/trade.tsx
+++ b/packages/frontend/src/context/trade.tsx
@@ -36,7 +36,7 @@ type tradeContextType = {
   inputQuote: string
   setInputQuote: (q: string) => void
   inputQuoteLoading: boolean
-  setInputQuoteLaoding: (bool: boolean) => void
+  setInputQuoteLoading: (bool: boolean) => void
   inputType: InputType
   setInputType: (type: InputType) => void
   sellCloseQuote: SellCloseQuote
@@ -78,7 +78,7 @@ const initialState: tradeContextType = {
   setInputQuote: () => null,
   quote: quoteEmptyState,
   inputQuoteLoading: false,
-  setInputQuoteLaoding: () => null,
+  setInputQuoteLoading: () => null,
   sellCloseQuote: sellCloseEmptyState,
   inputType: InputType.ETH,
   setInputType: () => null,
@@ -103,7 +103,7 @@ const TradeProvider: React.FC = ({ children }) => {
   const [openPosition, setOpenPosition] = useState(0)
   const [quote, setQuote] = useState(quoteEmptyState)
   const [inputQuote, setInputQuote] = useState('')
-  const [inputQuoteLoading, setInputQuoteLaoding] = useState(false)
+  const [inputQuoteLoading, setInputQuoteLoading] = useState(false)
   const [inputType, setInputType] = useState(InputType.ETH)
   const [sellCloseQuote, setSellCloseQuote] = useState(sellCloseEmptyState)
   const [squeethExposure, setSqueethExposure] = useState(0)
@@ -133,7 +133,7 @@ const TradeProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     if (!ready) return
-    setInputQuoteLaoding(true)
+    setInputQuoteLoading(true)
     //tradeType refers to which tab "Long" or "Short" is selected on the trade page
     //positionType refers to the user's actual position based on their squeeth balances and debt
     //isPositionOpen is true if the "Open" tab is selected on the trade page; otherwise it refers to the "Close" tab being selected
@@ -179,7 +179,7 @@ const TradeProvider: React.FC = ({ children }) => {
         getBuyQuote(new BigNumber(tradeAmount), slippageAmount).then(setSellCloseQuote)
       }
     }
-    setInputQuoteLaoding(false)
+    setInputQuoteLoading(false)
   }, [
     tradeAmount,
     altTradeAmount,
@@ -200,7 +200,7 @@ const TradeProvider: React.FC = ({ children }) => {
       if (inputType === InputType.ETH) setTradeAmount(inputQuote)
       else setAltTradeAmount(inputQuote)
     }
-    setInputQuoteLaoding(false)
+    setInputQuoteLoading(false)
   }, [inputQuote])
 
   useEffect(() => {
@@ -238,7 +238,7 @@ const TradeProvider: React.FC = ({ children }) => {
     inputQuote,
     setInputQuote,
     inputQuoteLoading,
-    setInputQuoteLaoding,
+    setInputQuoteLoading,
     confirmedAmount,
     setConfirmedAmount,
     inputType,


### PR DESCRIPTION
# Task: Fix bignumber in dependency arrays

## Description
- Some useEffect and useCallback on the long and short trade cards had bigNumber elements in dependency arrays, changed those to toString()

Fixes # (issue)
Contributes to #46 but not closing because I think more investigation required as well 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
