### PR TITLE
Fix .reduce bug that crashes app

### DIFF
--- a/packages/frontend/src/hooks/useETHPriceCharts.tsx
+++ b/packages/frontend/src/hooks/useETHPriceCharts.tsx
@@ -37,10 +37,12 @@ export function useETHPriceCharts(initDays = 365, initVolMultiplier = 1.2, initC
     return acc
   }, {})
 
-  const ethWithinOneDayPriceMap = allEthWithinOneDayPrices.reduce((acc: any, p) => {
-    acc[p.time] = p.value
-    return acc
-  }, {})
+  const ethWithinOneDayPriceMap = allEthWithinOneDayPrices?.length
+    ? allEthWithinOneDayPrices.reduce((acc: any, p) => {
+        acc[p.time] = p.value
+        return acc
+      }, {})
+    : {}
 
   /**
    * cUSDC yield as PNL


### PR DESCRIPTION
# Task:
Fix .reduce bug that crashes app

## Description

This stops reduce method from running if array is empty

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

This PR can be tested by checking to see if the app crashes due to the reduce methods in useUsdAmount.ts

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
