### PR TITLE
fix: collateral to redeem field on short close

### DIFF
--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -643,7 +643,10 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
       getDebtAmount(new BigNumber(restOfShort)).then((debt) => {
         const _neededCollat = debt.times(collatPercent / 100)
         setNeededCollat(_neededCollat)
-        setWithdrawCollat(_collat.minus(neededCollat))
+        console.log('needed collat ' + _neededCollat)
+        console.log('existincollat collat ' + _collat)
+        setWithdrawCollat(_neededCollat.gt(0) ? _collat.minus(neededCollat) : _collat)
+        console.log('withdraw collat ' + _collat.minus(neededCollat))
       })
     }
   }, [amount.toString(), collatPercent, shortVaults?.length])

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -643,10 +643,7 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
       getDebtAmount(new BigNumber(restOfShort)).then((debt) => {
         const _neededCollat = debt.times(collatPercent / 100)
         setNeededCollat(_neededCollat)
-        console.log('needed collat ' + _neededCollat)
-        console.log('existincollat collat ' + _collat)
         setWithdrawCollat(_neededCollat.gt(0) ? _collat.minus(neededCollat) : _collat)
-        console.log('withdraw collat ' + _collat.minus(neededCollat))
       })
     }
   }, [amount.toString(), collatPercent, shortVaults?.length])


### PR DESCRIPTION
# Task: Fix collateral to redeem field on short close

## Description
- When a user inputs an amount of oSQTH greater than their short amount in their vault, the collateral to redeem field shows the wrong value 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
