### PR TITLE
Use world context instead of trade context for eth price and osqth bal

### DIFF
--- a/packages/frontend/pages/positions.tsx
+++ b/packages/frontend/pages/positions.tsx
@@ -12,7 +12,7 @@ import History from '@components/Trade/History'
 import { PositionType } from '../src/types/'
 import { Tooltips, TransactionType, OSQUEETH_DECIMALS } from '../src/constants'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 import { useLPPositions, usePnL, usePositions } from '@hooks/usePositions'
 import { useTransactionHistory } from '@hooks/useTransactionHistory'
 import { useVaultLiquidations } from '@hooks/contracts/useLiquidations'
@@ -122,7 +122,7 @@ export function Positions() {
   const { activePositions, loading: isPositionFinishedCalc } = useLPPositions()
   const { pool } = useSqueethPool()
 
-  const { oSqueethBal } = useTrade()
+  const { oSqueethBal } = useWorldContext()
 
   const {
     positionType,
@@ -134,6 +134,7 @@ export function Positions() {
     vaultId,
     existingCollat,
     lpedSqueeth,
+    isLong,
   } = usePositions()
 
   const { index, getCollatRatioAndLiqPrice } = useController()
@@ -260,7 +261,9 @@ export function Positions() {
                   <Typography variant="caption" component="span" color="textSecondary">
                     Realized P&L
                   </Typography>
-                  <Tooltip title={Tooltips.RealizedPnL}>
+                  <Tooltip
+                    title={isLong ? Tooltips.RealizedPnL : `${Tooltips.RealizedPnL}. ${Tooltips.ShortCollateral}`}
+                  >
                     <InfoIcon fontSize="small" className={classes.infoIcon} />
                   </Tooltip>
                   <Typography variant="body1" className={longRealizedPNL.gte(0) ? classes.green : classes.red}>
@@ -300,7 +303,9 @@ export function Positions() {
                   <Typography variant="caption" color="textSecondary">
                     Unrealized P&L
                   </Typography>
-                  <Tooltip title={Tooltips.UnrealizedPnL}>
+                  <Tooltip
+                    title={isLong ? Tooltips.UnrealizedPnL : `${Tooltips.UnrealizedPnL}. ${Tooltips.ShortCollateral}`}
+                  >
                     <InfoIcon fontSize="small" className={classes.infoIcon} />
                   </Tooltip>
                   {isPositionFinishedCalc || shortGain.isLessThanOrEqualTo(-100) || !shortGain.isFinite() ? (

--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -28,7 +28,7 @@ import { useRestrictUser } from '@context/restrict-user'
 import { useWallet } from '@context/wallet'
 import { useController } from '../../src/hooks/contracts/useController'
 import { useVaultLiquidations } from '@hooks/contracts/useLiquidations'
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 import { CollateralStatus, Vault } from '../../src/types'
 import { squeethClient } from '@utils/apollo-client'
 import { getCollatPercentStatus, toTokenAmount } from '@utils/calculations'
@@ -233,7 +233,7 @@ const Component: React.FC = () => {
   const { liquidations } = useVaultLiquidations(Number(vid))
   const { positionType, squeethAmount } = usePositions()
 
-  const { oSqueethBal } = useTrade()
+  const { oSqueethBal } = useWorldContext()
 
   const [vault, setVault] = useState<Vault | null>(null)
   const [existingCollatPercent, setExistingCollatPercent] = useState(0)

--- a/packages/frontend/src/components/Charts/LongChart.tsx
+++ b/packages/frontend/src/components/Charts/LongChart.tsx
@@ -13,11 +13,10 @@ import InfoIcon from '@material-ui/icons/InfoOutlined'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
 import React, { useEffect, useMemo, useState } from 'react'
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 import ComparisonChart from '../../../public/images/ComparisonChart.svg'
 import { graphOptions } from '../../constants/diagram'
 import { Links, Tooltips } from '../../constants/enums'
-import { useWorldContext } from '../../context/world'
 import IV from '../IV'
 import { SqueethTab, SqueethTabs } from '../Tabs'
 import LongSqueethPayoff from './LongSqueethPayoff'
@@ -97,7 +96,7 @@ export function LongChart() {
   const [tradeType, setTradeType] = useState(0)
 
   const classes = useStyles()
-  const { ethPrice } = useTrade()
+  const { ethPrice } = useWorldContext()
 
   useEffect(() => {
     if (tradeType === 0) setMode(ChartType.PNL)

--- a/packages/frontend/src/components/Charts/VaultChart.tsx
+++ b/packages/frontend/src/components/Charts/VaultChart.tsx
@@ -5,7 +5,6 @@ import React, { useMemo, useState } from 'react'
 
 import { graphOptions, Links, Vaults } from '../../constants'
 import { useWorldContext } from '../../context/world'
-import { useTrade } from '../../context/trade'
 import { SqueethTab, SqueethTabs } from '../Tabs'
 import ShortSqueethPayoff from './ShortSqueethPayoff'
 
@@ -83,7 +82,7 @@ export function VaultChart({
     collatRatio,
   } = useWorldContext()
 
-  const { ethPrice } = useTrade()
+  const { ethPrice } = useWorldContext()
 
   const seriesRebalance = getVaultPNLWithRebalance(longAmount)
   const classes = useStyles()

--- a/packages/frontend/src/components/Lp/GetSqueeth.tsx
+++ b/packages/frontend/src/components/Lp/GetSqueeth.tsx
@@ -9,7 +9,7 @@ import { LPActions, OBTAIN_METHOD, useLPState } from '@context/lp'
 import { useWallet } from '@context/wallet'
 import { useController } from '@hooks/contracts/useController'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 import { usePositions } from '@hooks/usePositions'
 import { toTokenAmount } from '@utils/calculations'
 import { PrimaryButton } from '../Button'
@@ -67,7 +67,7 @@ const useStyles = makeStyles((theme) =>
 
 const Mint: React.FC = () => {
   const classes = useStyles()
-  const { oSqueethBal } = useTrade()
+  const { oSqueethBal } = useWorldContext()
   const { balance, connected } = useWallet()
   const { existingCollatPercent, existingCollat, firstValidVault } = usePositions()
   const { vaults: shortVaults, loading: vaultIDLoading } = useVaultManager()

--- a/packages/frontend/src/components/Lp/LPTable.tsx
+++ b/packages/frontend/src/components/Lp/LPTable.tsx
@@ -21,7 +21,7 @@ import { useEffect, useState } from 'react'
 import { SecondaryTab, SecondaryTabs } from '../../components/Tabs'
 import { Tooltips, UniswapIFrameOpen, UniswapIFrameClose } from '@constants/enums'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 import { useLPPositions } from '@hooks/usePositions'
 import { inRange } from '@utils/calculations'
 import { UniswapIframe } from '../Modal/UniswapIframe'
@@ -117,7 +117,7 @@ export const LPTable: React.FC<LPTableProps> = ({ isLPage, pool }) => {
   const classes = useStyles()
   const { activePositions, closedPositions, loading: lpLoading } = useLPPositions()
   const [activeTab, setActiveTab] = useState(0)
-  const { ethPrice } = useTrade()
+  const { ethPrice } = useWorldContext()
   const { getWSqueethPositionValue, isWethToken0 } = useSqueethPool()
   const { networkId } = useWallet()
 

--- a/packages/frontend/src/components/PositionCard.tsx
+++ b/packages/frontend/src/components/PositionCard.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { usePnL, usePositions } from '@hooks/usePositions'
 import { Tooltips } from '@constants/enums'
 import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 import { PositionType, TradeType } from '../types'
 import { useController } from '@hooks/contracts/useController'
 import { toTokenAmount } from '@utils/calculations'
@@ -171,6 +172,7 @@ const PositionCard: React.FC<PositionCardType> = ({ tradeCompleted }) => {
     existingCollat,
     loading: isPositionLoading,
     isLP,
+    isLong,
   } = usePositions()
   const { liquidations } = useVaultLiquidations(Number(vaultId))
   const {
@@ -181,8 +183,8 @@ const PositionCard: React.FC<PositionCardType> = ({ tradeCompleted }) => {
     tradeSuccess,
     setTradeSuccess,
     tradeType,
-    ethPrice,
   } = useTrade()
+  const { ethPrice } = useWorldContext()
   const tradeAmount = new BigNumber(tradeAmountInput)
   const { index } = useController()
   const [fetchingNew, setFetchingNew] = useState(false)
@@ -348,7 +350,9 @@ const PositionCard: React.FC<PositionCardType> = ({ tradeCompleted }) => {
                     <Typography variant="caption" color="textSecondary" style={{ fontWeight: 500 }}>
                       Unrealized P&L
                     </Typography>
-                    <Tooltip title={Tooltips.UnrealizedPnL}>
+                    <Tooltip
+                      title={isLong ? Tooltips.UnrealizedPnL : `${Tooltips.UnrealizedPnL}. ${Tooltips.ShortCollateral}`}
+                    >
                       <InfoIcon fontSize="small" className={classes.infoIcon} />
                     </Tooltip>
                   </div>
@@ -380,7 +384,9 @@ const PositionCard: React.FC<PositionCardType> = ({ tradeCompleted }) => {
                   <Typography variant="caption" color="textSecondary" style={{ fontWeight: 500 }}>
                     Realized P&L
                   </Typography>
-                  <Tooltip title={Tooltips.RealizedPnL}>
+                  <Tooltip
+                    title={isLong ? Tooltips.RealizedPnL : `${Tooltips.RealizedPnL}. ${Tooltips.ShortCollateral}`}
+                  >
                     <InfoIcon fontSize="small" className={classes.infoIcon} />
                   </Tooltip>
                 </div>

--- a/packages/frontend/src/components/Trade/History.tsx
+++ b/packages/frontend/src/components/Trade/History.tsx
@@ -5,7 +5,7 @@ import { EtherscanPrefix } from '../../constants'
 import { TransactionType } from '@constants/enums'
 import { useWallet } from '@context/wallet'
 import { useController } from '@hooks/contracts/useController'
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 import { useTransactionHistory } from '@hooks/useTransactionHistory'
 import { useUsdAmount } from '@hooks/useUsdAmount'
 const useStyles = makeStyles((theme) =>
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme) =>
 const History: React.FC = () => {
   const { transactions } = useTransactionHistory()
   const { networkId } = useWallet()
-  const { ethPrice } = useTrade()
+  const { ethPrice } = useWorldContext()
   const { normFactor: normalizationFactor } = useController()
   const classes = useStyles()
   const { getUsdAmt } = useUsdAmount()

--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -34,6 +34,7 @@ export enum Tooltips {
   ImplVol = 'Implied Volatility (IV) is a market forecast of ETH price movement implied by squeeth',
   UnrealizedPnL = 'Total profit / loss if you were to fully close your position at the current oSQTH price on Uniswap. Resets if you close your position or change position sides (long to short, or vice versa)',
   RealizedPnL = 'Total realized profit / loss for this position through partial closes. Resets if you fully close your position or change position sides (long to short, or vice versa)',
+  ShortCollateral = 'Takes ETH collateral into account',
   Mark = 'The price squeeth is trading at. Because squeeth has convexity, Mark should be greater than ETH^2',
   Last30MinAvgFunding = 'Historical daily funding based on the last 30min. Calculated using a 30min TWAP of Mark - Index',
   CurrentImplFunding = 'Expected daily funding based on current price, calculated using current Mark - Index',

--- a/packages/frontend/src/context/lp.tsx
+++ b/packages/frontend/src/context/lp.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useReducer } from 'react'
 import { Reducer } from 'react-transition-group/node_modules/@types/react'
 
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 
 export enum Steps {
   SELECT_METHOD = 1,
@@ -82,7 +82,7 @@ const useLPState = () => useContext<LPContextType>(LPContext)
 
 const LPProvider: React.FC = ({ children }) => {
   const [lpState, dispatch] = useReducer<Reducer<LPType, ActionType>>(tradeReducer, initialState)
-  const { oSqueethBal } = useTrade()
+  const { oSqueethBal } = useWorldContext()
 
   useEffect(() => {
     if (oSqueethBal.isZero() || lpState.step === Steps.PROVIDE_LIQUIDITY) return

--- a/packages/frontend/src/context/trade.tsx
+++ b/packages/frontend/src/context/trade.tsx
@@ -1,12 +1,9 @@
 import BigNumber from 'bignumber.js'
 import React, { useContext, useEffect, useMemo, useState } from 'react'
 
-import { DEFAULT_SLIPPAGE, InputType, OSQUEETH_DECIMALS } from '../constants/index'
+import { DEFAULT_SLIPPAGE, InputType } from '../constants/index'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
-import { useETHPrice } from '@hooks/useETHPrice'
-import { useTokenBalance } from '@hooks/contracts/useTokenBalance'
 import { usePnL } from '@hooks/usePositions'
-import { useAddresses } from '@hooks/useAddress'
 import { PositionType, TradeType } from '../types'
 
 type Quote = {
@@ -49,10 +46,6 @@ type tradeContextType = {
   setSlippageAmount: (amt: BigNumber) => void
   confirmedAmount: string
   setConfirmedAmount: (amt: string) => void
-  ethPrice: BigNumber
-  setETHPrice: (amt: BigNumber) => void
-  oSqueethBal: BigNumber
-  setOSqueethBal: (amt: BigNumber) => void
 }
 
 const quoteEmptyState = {
@@ -95,10 +88,6 @@ const initialState: tradeContextType = {
   setSlippageAmount: () => null,
   confirmedAmount: '0',
   setConfirmedAmount: () => null,
-  ethPrice: new BigNumber(0),
-  setETHPrice: () => null,
-  oSqueethBal: new BigNumber(0),
-  setOSqueethBal: () => null,
 }
 
 const tradeContext = React.createContext<tradeContextType>(initialState)
@@ -120,8 +109,6 @@ const TradeProvider: React.FC = ({ children }) => {
   const [squeethExposure, setSqueethExposure] = useState(0)
   const [actualTradeType, setActualTradeType] = useState(TradeType.LONG)
   const [confirmedAmount, setConfirmedAmount] = useState('0')
-  const [ethPrice, setETHPrice] = useState(new BigNumber(0))
-  const [oSqueethBal, setOSqueethBal] = useState(new BigNumber(0))
 
   const {
     ready,
@@ -134,20 +121,9 @@ const TradeProvider: React.FC = ({ children }) => {
     getSellQuoteForETH,
   } = useSqueethPool()
   const { positionType } = usePnL()
-  const { oSqueeth } = useAddresses()
-  const _ethPrice = useETHPrice()
-  const _oSqueethBal = useTokenBalance(oSqueeth, 15, OSQUEETH_DECIMALS)
 
   const amountOutBN = quote.amountOut
   const isPositionOpen = useMemo(() => openPosition === 0, [openPosition])
-
-  useMemo(() => {
-    if (_ethPrice) setETHPrice(_ethPrice)
-  }, [_ethPrice.toString()])
-
-  useMemo(() => {
-    if (_oSqueethBal) setOSqueethBal(_oSqueethBal)
-  }, [_oSqueethBal.toString()])
 
   useEffect(() => {
     setTradeAmount('0')
@@ -271,10 +247,6 @@ const TradeProvider: React.FC = ({ children }) => {
     setAltTradeAmount,
     slippageAmount,
     setSlippageAmount,
-    ethPrice,
-    setETHPrice,
-    oSqueethBal,
-    setOSqueethBal,
   }
 
   return <tradeContext.Provider value={store}>{children}</tradeContext.Provider>

--- a/packages/frontend/src/hooks/contracts/useController.ts
+++ b/packages/frontend/src/hooks/contracts/useController.ts
@@ -222,6 +222,7 @@ export const useController = () => {
     )
     // return () => sub.unsubscribe()
   }, [web3, networkId, getIndex])
+
   const getFundingForHalfHour = async () => {
     let index
     let mark

--- a/packages/frontend/src/hooks/contracts/useSqueethPool.ts
+++ b/packages/frontend/src/hooks/contracts/useSqueethPool.ts
@@ -16,7 +16,7 @@ import { fromTokenAmount, parseSlippageInput, toTokenAmount } from '@utils/calcu
 import { useAddresses } from '../useAddress'
 import { Networks } from '../../types'
 import useUniswapTicks from '../useUniswapTicks'
-import { useTrade } from '@context/trade'
+import { useWorldContext } from '@context/world'
 // import univ3prices from '@thanpolas/univ3prices'
 const univ3prices = require('@thanpolas/univ3prices')
 
@@ -40,7 +40,7 @@ export const useSqueethPool = () => {
   const [wethPrice, setWethPrice] = useState<BigNumber>(new BigNumber(0))
   const [ready, setReady] = useState(false)
   const [tvl, setTVL] = useState(0)
-  const { ethPrice } = useTrade()
+  const { ethPrice } = useWorldContext()
 
   const { address, web3, networkId, handleTransaction } = useWallet()
   const { squeethPool, swapRouter, quoter, weth, oSqueeth } = useAddresses()

--- a/packages/frontend/src/hooks/usePositions.ts
+++ b/packages/frontend/src/hooks/usePositions.ts
@@ -17,7 +17,6 @@ import { useController } from './contracts/useController'
 import { useSqueethPool } from './contracts/useSqueethPool'
 import { useVaultManager } from './contracts/useVaultManager'
 import { useAddresses } from './useAddress'
-import { useTrade } from '@context/trade'
 import useInterval from './useInterval'
 import { useUsdAmount } from './useUsdAmount'
 import { useTransactionHistory } from './useTransactionHistory'
@@ -463,7 +462,7 @@ export const usePnL = () => {
   } = useLongPositions()
   const { usdAmount: shortUsdAmt, realizedPNL: shortRealizedPNL, refetch: refetchShort } = useShortPositions()
   const { positionType, squeethAmount, wethAmount, shortVaults, loading: positionLoading } = usePositions()
-  const { ethPrice } = useTrade()
+  const { ethPrice } = useWorldContext()
   const { ready, getSellQuote, getBuyQuote } = useSqueethPool()
   const { swapTransactions: transactions } = useTransactionHistory()
   const { index } = useController()
@@ -573,7 +572,7 @@ export const useLPPositions = () => {
   const { address, web3 } = useWallet()
   const { squeethPool, nftManager, weth, oSqueeth } = useAddresses()
   const { pool, getWSqueethPositionValue, squeethInitialPrice } = useSqueethPool()
-  const { ethPrice } = useTrade()
+  const { ethPrice } = useWorldContext()
 
   const [activePositions, setActivePositions] = useState<NFTManagers[]>([])
   const [closedPositions, setClosedPositions] = useState<NFTManagers[]>([])


### PR DESCRIPTION
# Task: Use world context instead of trade context for eth price and osqth bal

## Description
Need to use a global context for eth price and oSQTH bal instead of trade context which doesn't reach all components 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
