### PR TITLE
Add tooltips, timezone, update slippage and descriptions

### DIFF
--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -19,6 +19,8 @@ import { useWorldContext } from '@context/world'
 import BigNumber from 'bignumber.js'
 import React, { useState } from 'react'
 import { Tooltips } from '@constants/index'
+import TradeInfoItem from '@components/Trade/TradeInfoItem'
+import { TradeSettings } from '@components/TradeSettings'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -73,6 +75,12 @@ const useStyles = makeStyles((theme) =>
       zIndex: 20,
       // background: '#2A2D2E',
     },
+    settingsButton: {
+      marginTop: theme.spacing(2),
+      marginLeft: theme.spacing(37),
+      justifyContent: 'right',
+      alignSelf: 'center',
+    },
   }),
 )
 
@@ -80,7 +88,7 @@ const Strategies: React.FC = () => {
   const [ethAmount, setEthAmount] = useState(new BigNumber(0))
   const [withdrawAmount, setWithdrawAmount] = useState(new BigNumber(0))
   const [depositOption, setDepositOption] = useState(0)
-  const [slippage, setSlippage] = useState(0.5)
+  const [slippage, setSlippage] = useState(new BigNumber(0.5))
   const [txLoading, setTxLoading] = useState(false)
   const [txLoaded, setTxLoaded] = useState(false)
   const [txHash, setTxHash] = useState('')
@@ -97,7 +105,7 @@ const Strategies: React.FC = () => {
   const deposit = async () => {
     setTxLoading(true)
     try {
-      const tx = await flashDeposit(ethAmount, slippage)
+      const tx = await flashDeposit(ethAmount, slippage.toNumber())
       setTxHash(tx.transactionHash)
       setTxLoaded(true)
     } catch (e) {
@@ -109,7 +117,7 @@ const Strategies: React.FC = () => {
   const withdraw = async () => {
     setTxLoading(true)
     try {
-      const tx = await flashWithdraw(withdrawAmount, slippage)
+      const tx = await flashWithdraw(withdrawAmount, slippage.toNumber())
       setTxHash(tx.transactionHash)
       setTxLoaded(true)
     } catch (e) {
@@ -204,6 +212,9 @@ const Strategies: React.FC = () => {
                   <SecondaryTab label="Deposit" />
                   <SecondaryTab label="Withdraw" />
                 </SecondaryTabs>
+                <div className={classes.settingsButton}>
+                  <TradeSettings isCrab={true} setCrabSlippage={setSlippage} crabSlippage={slippage} />
+                </div>
                 <div className={classes.tradeContainer}>
                   {depositOption === 0 ? (
                     <PrimaryInput
@@ -230,7 +241,13 @@ const Strategies: React.FC = () => {
                       onActionClicked={() => setWithdrawAmount(crabBalance)}
                     />
                   )}
-                  <TextField
+                  <TradeInfoItem
+                    label="Slippage"
+                    value={slippage.toString()}
+                    tooltip="The strategy uses a uniswap flashswap to make a deposit. You can adjust slippage for this swap by clicking the gear icon"
+                    unit="%"
+                  />
+                  {/* <TextField
                     size="small"
                     value={slippage}
                     type="number"
@@ -250,7 +267,7 @@ const Strategies: React.FC = () => {
                     inputProps={{
                       min: '0',
                     }}
-                  />
+                  /> */}
                   {depositOption === 0 ? (
                     <PrimaryButton
                       variant="contained"

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -8,15 +8,17 @@ import StrategyInfoItem from '@components/Strategies/StrategyInfoItem'
 import { SecondaryTab, SecondaryTabs } from '@components/Tabs'
 import Confirmed, { ConfirmType } from '@components/Trade/Confirmed'
 import { useWallet } from '@context/wallet'
-import { useWorldContext } from '@context/world'
 import { useCrabStrategy } from '@hooks/contracts/useCrabStrategy'
 import { useTokenBalance } from '@hooks/contracts/useTokenBalance'
 import { useAddresses } from '@hooks/useAddress'
 import { CircularProgress, InputAdornment, TextField, Typography } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
+import { useController } from '@hooks/contracts/useController'
 import { toTokenAmount } from '@utils/calculations'
+import { useWorldContext } from '@context/world'
 import BigNumber from 'bignumber.js'
 import React, { useState } from 'react'
+import { Tooltips } from '@constants/index'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -89,6 +91,7 @@ const Strategies: React.FC = () => {
     useCrabStrategy()
   const { crabStrategy } = useAddresses()
   const crabBalance = useTokenBalance(crabStrategy, 10, 18)
+  const { index } = useController()
   const { ethPrice } = useWorldContext()
 
   const deposit = async () => {
@@ -134,7 +137,12 @@ const Strategies: React.FC = () => {
           <div className={classes.details}>
             <CapDetails maxCap={maxCap} depositedAmount={vault?.collateralAmount || new BigNumber(0)} />
             <div className={classes.overview}>
-              <StrategyInfoItem value={ethPrice.toFixed(2)} label="ETH Price ($)" />
+              <StrategyInfoItem
+                value={Number(toTokenAmount(index, 18).sqrt()).toFixed(2).toLocaleString()}
+                label="ETH Price ($)"
+                tooltip={Tooltips.SpotPrice}
+                priceType="spot"
+              />
               <StrategyInfoItem value={vault?.shortAmount.toFixed(4)} label="Short oSQTH" />
               <StrategyInfoItem value={crabBalance.toFixed(4)} label="Position (CRAB)" />
             </div>
@@ -142,14 +150,27 @@ const Strategies: React.FC = () => {
               <StrategyInfoItem
                 value={new Date(timeAtLastHedge * 1000).toLocaleString(undefined, {
                   day: 'numeric',
-                  month: 'short',
+                  month: 'numeric',
                   hour: 'numeric',
                   minute: 'numeric',
+                  timeZoneName: 'short',
+                  hour12: false,
                 })}
                 label="Last rebalanced at"
+                tooltip={new Date(timeAtLastHedge * 1000).toLocaleString(undefined, {
+                  day: 'numeric',
+                  month: 'long',
+                  hour: 'numeric',
+                  minute: 'numeric',
+                  timeZoneName: 'long',
+                })}
               />
               <StrategyInfoItem value={collatRatio.toString()} label="Collat Ratio (%)" />
-              <StrategyInfoItem value={liquidationPrice.toFixed(2)} label="Liquidation price ($)" />
+              <StrategyInfoItem
+                value={liquidationPrice.toFixed(2)}
+                label="Liq Price ($)"
+                tooltip={`${Tooltips.LiquidationPrice} ${Tooltips.VaultLiquidations}`}
+              />
             </div>
             <StrategyInfo />
             <CrabStrategyHistory />

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -21,6 +21,7 @@ import React, { useState } from 'react'
 import { Tooltips } from '@constants/index'
 import TradeInfoItem from '@components/Trade/TradeInfoItem'
 import { TradeSettings } from '@components/TradeSettings'
+import { Links } from '@constants/enums'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -81,6 +82,9 @@ const useStyles = makeStyles((theme) =>
       justifyContent: 'right',
       alignSelf: 'center',
     },
+    link: {
+      color: theme.palette.primary.main,
+    },
   }),
 )
 
@@ -137,9 +141,13 @@ const Strategies: React.FC = () => {
           </Typography>
         </div>
         <Typography variant="subtitle1" color="textSecondary" style={{ width: '60%', marginTop: '8px' }}>
-          This yielding position is similar to selling a strangle. You are profitable as long as ETH moves less than
-          approximately 6% in either direction in a single day. The strategy rebalances daily to be delta neutral by
-          buying or selling oSQTH.
+          This yielding position allows depositors to collect funding from being short squeeth and long ETH, targeting
+          being delta neutral. You are profitable as long as ETH moves less than approximately 6% in either direction in
+          a single day, where the exact percentage move changes daily subject to volatility.{' '}
+          <a className={classes.link} href={Links.CrabFAQ} target="_blank" rel="noreferrer">
+            {' '}
+            Learn more.{' '}
+          </a>
         </Typography>
         <div className={classes.body}>
           <div className={classes.details}>

--- a/packages/frontend/src/components/Strategies/StrategyInfoItem.tsx
+++ b/packages/frontend/src/components/Strategies/StrategyInfoItem.tsx
@@ -1,6 +1,10 @@
 import { Typography } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import React from 'react'
+import AccessTimeIcon from '@material-ui/icons/AccessTime'
+import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
+import { Tooltip } from '@material-ui/core'
+import InfoIcon from '@material-ui/icons/InfoOutlined'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -20,21 +24,45 @@ const useStyles = makeStyles((theme) =>
     overviewValue: {
       fontSize: '22px',
     },
+    infoIcon: {
+      fontSize: '1rem',
+      marginLeft: theme.spacing(0.5),
+      marginTop: '2px',
+      color: theme.palette.text.secondary,
+    },
+    infoLabel: {
+      display: 'flex',
+    },
   }),
 )
 
 type StrategyProps = {
   value?: string
   label: string
+  tooltip?: React.ReactNode
+  priceType?: string
 }
 
-const StrategyInfoItem: React.FC<StrategyProps> = ({ value, label }) => {
+const StrategyInfoItem: React.FC<StrategyProps> = ({ value, label, tooltip, priceType }) => {
   const classes = useStyles()
 
   return (
     <div className={classes.container}>
       <Typography className={classes.overviewValue}>{value}</Typography>
-      <Typography className={classes.overviewTitle}>{label}</Typography>
+      <div className={classes.infoLabel}>
+        <Typography className={classes.overviewTitle}>{label} </Typography>
+        {tooltip ? (
+          <Tooltip title={tooltip}>
+            {priceType === 'twap' ? (
+              <AccessTimeIcon className={classes.infoIcon} />
+            ) : priceType === 'spot' ? (
+              <FiberManualRecordIcon className={classes.infoIcon} />
+            ) : (
+              <InfoIcon className={classes.infoIcon} />
+            )}
+          </Tooltip>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/packages/frontend/src/components/TradeSettings.tsx
+++ b/packages/frontend/src/components/TradeSettings.tsx
@@ -46,7 +46,13 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-export const TradeSettings: React.FC = () => {
+type TradeSettingsProps = {
+  isCrab?: boolean
+  setCrabSlippage?: (amt: BigNumber) => void
+  crabSlippage?: BigNumber
+}
+
+export const TradeSettings: React.FC<TradeSettingsProps> = ({ isCrab, setCrabSlippage, crabSlippage }) => {
   const classes = useStyles()
 
   const { slippageAmount, setSlippageAmount } = useTrade()
@@ -86,11 +92,15 @@ export const TradeSettings: React.FC = () => {
         <DialogContent className={classes.dialogContent}>
           <TextField
             size="small"
-            value={slippageAmount}
+            value={isCrab ? crabSlippage : slippageAmount}
             type="number"
             className={classes.slippageInput}
             margin="dense"
-            onChange={(event) => setSlippageAmount(new BigNumber(event.target.value))}
+            onChange={
+              isCrab
+                ? (event) => (setCrabSlippage ? setCrabSlippage(new BigNumber(event.target.value)) : null)
+                : (event) => setSlippageAmount(new BigNumber(event.target.value))
+            }
             id="filled-basic"
             label="Slippage Tolerance"
             variant="outlined"

--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -65,6 +65,7 @@ export enum Links {
   BacktestFAQ = 'https://opyn.gitbook.io/squeeth/resources/squeeth-faq#what-is-the-historical-365d-pnl',
   GitBook = 'https://opyn.gitbook.io/squeeth/',
   UniswapSwap = 'https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=0xf1B99e3E573A1a9C5E6B2Ce818b617F0E664E86B',
+  CrabFAQ = 'https://opyn.gitbook.io/squeeth/resources/squeeth-strategies-faq',
 }
 
 export const UniswapIFrameOpen = {

--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -34,7 +34,7 @@ export enum Tooltips {
   ImplVol = 'Implied Volatility (IV) is a market forecast of ETH price movement implied by squeeth',
   UnrealizedPnL = 'Total profit / loss if you were to fully close your position at the current oSQTH price on Uniswap. Resets if you close your position or change position sides (long to short, or vice versa)',
   RealizedPnL = 'Total realized profit / loss for this position through partial closes. Resets if you fully close your position or change position sides (long to short, or vice versa)',
-  ShortCollateral = 'Takes ETH collateral into account',
+  ShortCollateral = 'Takes ETH collateral into account.',
   Mark = 'The price squeeth is trading at. Because squeeth has convexity, Mark should be greater than ETH^2',
   Last30MinAvgFunding = 'Historical daily funding based on the last 30min. Calculated using a 30min TWAP of Mark - Index',
   CurrentImplFunding = 'Expected daily funding based on current price, calculated using current Mark - Index',
@@ -46,7 +46,7 @@ export enum Tooltips {
   SellCloseAmount = 'Amount of oSQTH to buy',
   CurrentCollRatio = 'Collateral ratio for current short position',
   SellOpenAmount = 'Minimum collateral amount is 7.5 ETH to ensure system solvency with sufficient liquidation incentive',
-  LiquidationPrice = 'Price of ETH when liquidation occurs',
+  LiquidationPrice = 'Price of ETH when liquidation occurs.',
   InitialPremium = 'Initial payment you get for selling squeeth on Uniswap',
   BacktestDisclaimer = 'This is historical backtest data and does not show the actual performance of squeeth. See the FAQ to learn more.',
   PercentOfPool = 'The amount of your liquidity compared to all current active liquidity',
@@ -58,6 +58,7 @@ export enum Tooltips {
   ShortDebt = 'This is squeeth that you acquired and sold',
   LPDebt = 'This is squeeth which you have opened a Uniswap pool to trade.',
   TotalDebt = 'Debt of the vault',
+  VaultLiquidations = 'The strategy is subject to liquidations if it goes below 150% collateral, but rebalancing based on large ETH price changes helps prevent a liquidation from occurring.',
 }
 
 export enum Links {


### PR DESCRIPTION
# Task: UI updates 

## Description
- Adds tooltips to liquidations, spot price, and rebalance time 
- Adds timezone to rebalance time 
- Updates slippage to the same pattern as the trade page, making it more of a default
- Updates descriptions to test 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested
Locally 

<img width="1081" alt="Screen Shot 2022-01-17 at 7 52 53 PM" src="https://user-images.githubusercontent.com/13340486/149868042-944c5adb-bfd1-4524-be86-7a0b832d465f.png">


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
