### PR TITLE
Add X-Frame-options

### DIFF
--- a/packages/frontend/next.config.js
+++ b/packages/frontend/next.config.js
@@ -1,6 +1,22 @@
+const securityHeaders = [
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+]
+
 module.exports = {
   reactStrictMode: true,
   images: {
     domains: ['media.giphy.com'],
+  },
+  async headers() {
+    return [
+      {
+        // Apply these headers to all routes in your application.
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ]
   },
 }


### PR DESCRIPTION
# Task:
Add X-Frame-options to avoid clickjacking

## Description
It is set to sameorigin so it can be displayed in the frame if it only has the same origin. Refer here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested
You can see X-Frame-options in the response header

<img width="357" alt="Screenshot 2022-01-20 at 9 45 32 PM" src="https://user-images.githubusercontent.com/24666922/150377914-3bb2353f-b95d-4cc2-929c-e2c21ce3a085.png">

