### PR TITLE
feat: some crab positions updates

### DIFF
--- a/packages/frontend/pages/positions.tsx
+++ b/packages/frontend/pages/positions.tsx
@@ -510,7 +510,7 @@ export function Positions() {
           <CrabPosition
             depositedEth={depositedEth}
             depositedUsd={depositedUsd}
-            loading={false}
+            loading={crabLoading}
             minCurrentEth={minCurrentEth}
             minCurrentUsd={minCurrentUsd}
             minPnL={minPnL}
@@ -573,26 +573,22 @@ const CrabPosition: React.FC<CrabPositionType> = ({
         <div className={classes.innerPositionData}>
           <div style={{ width: '50%' }}>
             <Typography variant="caption" component="span" color="textSecondary">
-              Deposited ETH
+              Deposited Amount
             </Typography>
-            <Typography variant="body1">
+            <Typography variant="body1">$ {depositedUsd.toFixed(2)}</Typography>
+            <Typography variant="body2" color="textSecondary">
               {depositedEth.toFixed(6)}
               &nbsp; ETH
-            </Typography>
-            <Typography variant="body2" color="textSecondary">
-              $ {depositedUsd.toFixed(2)}
             </Typography>
           </div>
           <div style={{ width: '50%' }}>
             <Typography variant="caption" component="span" color="textSecondary">
               Current Position
             </Typography>
-            <Typography variant="body1">
+            <Typography variant="body1">$ {minCurrentUsd.toFixed(2)}</Typography>
+            <Typography variant="body2" color="textSecondary">
               {minCurrentEth.toFixed(6)}
               &nbsp; ETH
-            </Typography>
-            <Typography variant="body2" color="textSecondary">
-              $ {minCurrentUsd.toFixed(2)}
             </Typography>
           </div>
         </div>
@@ -605,10 +601,10 @@ const CrabPosition: React.FC<CrabPositionType> = ({
               <InfoIcon fontSize="small" className={classes.infoIcon} />
             </Tooltip>
             <Typography variant="body1" className={minPnlUsd.gte(0) ? classes.green : classes.red}>
-              $ {minPnlUsd.toFixed(2)}
+              {!loading ? '$' + `${minPnlUsd.toFixed(2)}` : 'loading'}
             </Typography>
             <Typography variant="caption" className={minPnlUsd.gte(0) ? classes.green : classes.red}>
-              {minPnL.toFixed(2)}%
+              {!loading ? `${minPnL.toFixed(2)}` + '%' : 'loading'}
             </Typography>
           </div>
         </div>

--- a/packages/frontend/src/components/Strategies/Crab/CrabPosition.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabPosition.tsx
@@ -43,7 +43,7 @@ const CrabPosition: React.FC<CrabPositionType> = ({ value, pnl, loading }) => {
       {value.gt(0) ? (
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <Typography variant="h6">{loading ? 'Loading' : `${value.toFixed(2)} USD`}</Typography>
-          {!loading ? (
+          {!loading && pnl.isFinite() ? (
             <Typography
               variant="body2"
               style={{ marginLeft: '4px', fontWeight: 600 }}

--- a/packages/frontend/src/components/Strategies/Crab/CrabPosition.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabPosition.tsx
@@ -1,8 +1,10 @@
 import { useCrabPosition } from '@hooks/useCrabPosition'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import React, { useEffect, useState } from 'react'
-import { Typography } from '@material-ui/core'
+import { Typography, Tooltip } from '@material-ui/core'
 import BigNumber from 'bignumber.js'
+import InfoIcon from '@material-ui/icons/InfoOutlined'
+import { Tooltips } from '@constants/enums'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -16,6 +18,10 @@ const useStyles = makeStyles((theme) =>
     },
     red: {
       color: theme.palette.error.main,
+    },
+    infoIcon: {
+      fontSize: '10px',
+      marginLeft: theme.spacing(0.5),
     },
   }),
 )
@@ -46,6 +52,9 @@ const CrabPosition: React.FC<CrabPositionType> = ({ value, pnl, loading }) => {
               ({pnl.toFixed(2)} %)
             </Typography>
           ) : null}
+          <Tooltip title={Tooltips.MinCrabPnL}>
+            <InfoIcon fontSize="small" className={classes.infoIcon} />
+          </Tooltip>
         </div>
       ) : (
         <Typography variant="body2">--</Typography>

--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -61,7 +61,7 @@ export enum Tooltips {
   ShortDebt = 'This is squeeth that you acquired and sold',
   TotalDebt = 'Debt of the vault',
   VaultLiquidations = 'The strategy is subject to liquidations if it goes below 150% collateral, but rebalancing based on large ETH price changes helps prevent a liquidation from occurring.',
-  MinCrabPnL = 'This is the minimum Pnl that you get because of slippage',
+  MinCrabPnL = 'This is your minimum PnL, as it takes into account slippage on Uniswap since the strategy uses flashswaps to deposit and withdraw',
   StrategyLiquidations = 'The strategy is subject to liquidations if it goes below 150% collateral, but rebalancing based on large ETH price changes helps prevent a liquidation from occurring.',
   StrategyShort = 'The amount of oSQTH the whole strategy is short',
   StrategyCollRatio = 'The collateralization ratio for the whole strategy',


### PR DESCRIPTION
# Task: Crab positions UI updates

## Description
- Add loading state to PnL on crab positions 
- Update tooltip copy for min PnL 
- Add tooltip to strategies page positions card 
- Emphasize dollar values on positions page with ETH values in caption since strategy aims to be profitable in dollar terms
<img width="848" alt="Screen Shot 2022-01-22 at 1 49 34 PM" src="https://user-images.githubusercontent.com/13340486/150656560-c1b4d24b-8783-4384-9b9f-670dfe1b5ea1.png">

<img width="404" alt="Screen Shot 2022-01-22 at 1 48 49 PM" src="https://user-images.githubusercontent.com/13340486/150656562-2c1dbab7-6b37-455b-aa59-d2924d044687.png">


Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Added video recordings if it is a UI change
