### PR TITLE
fix: position showing minted when a user is long & short/open showing 0 on confirmation modal

### DIFF
--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -235,7 +235,6 @@ const OpenShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeComp
     if (!open) return
     const debt = collateral.times(100).dividedBy(new BigNumber(collatPercent))
     getShortAmountFromDebt(debt).then((s) => setAmount(s.toString()))
-    setConfirmedAmount(amount.toFixed(6).toString())
   }, [collatPercent, collateral.toString(), normalizationFactor.toString()])
 
   useEffect(() => {

--- a/packages/frontend/src/hooks/usePositions.ts
+++ b/packages/frontend/src/hooks/usePositions.ts
@@ -135,10 +135,14 @@ export const usePositions = () => {
   )
 
   const mintedDebt = useMemo(() => {
-    return oSqueethBal?.isGreaterThan(0) && positionType === PositionType.LONG
+    return shortVaults[vaultId]?.shortAmount.gt(0) &&
+      oSqueethBal?.isGreaterThan(0) &&
+      positionType === PositionType.LONG
       ? oSqueethBal.minus(squeethAmount)
-      : oSqueethBal
-  }, [oSqueethBal.toString(), positionType, squeethAmount.toString()])
+      : shortVaults[vaultId]?.shortAmount.gt(0) && oSqueethBal?.isGreaterThan(0)
+      ? oSqueethBal
+      : new BigNumber(0)
+  }, [oSqueethBal.toString(), positionType, squeethAmount.toString(), shortVaults?.length])
 
   const shortDebt = useMemo(() => {
     return positionType === PositionType.SHORT ? squeethAmount : new BigNumber(0)


### PR DESCRIPTION
# Task: Fix: position showing minted when user is long & short/open showing 0 on confirmation modal

## Description
- Fixes position showing minted when user is long by explicitly setting mintedDebt to 0 if a user does not have a short vault 
- Fixes short/open showing 0 on confirmation modal

<img width="919" alt="Screen Shot 2022-01-22 at 9 08 38 PM" src="https://user-images.githubusercontent.com/13340486/150665869-5ccad15b-39a6-4153-be8d-cc479a371d81.png">
<img width="353" alt="Screen Shot 2022-01-22 at 9 07 44 PM" src="https://user-images.githubusercontent.com/13340486/150665870-5901674c-64a4-4844-a994-57a429ad09c1.png">


Fixes # (issue)
part of #94 (the minted part, leaving it open because doesn't fix the switching part) #33

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
