### PR TITLE
feat: price impact colors and button change

### DIFF
--- a/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
@@ -224,24 +224,42 @@ const CrabTrade: React.FC<CrabTradeType> = ({ maxCap, depositedAmount }) => {
               tooltip="The strategy uses a uniswap flashswap to make a deposit. You can adjust slippage for this swap by clicking the gear icon"
               unit="%"
             />
-            <TradeInfoItem
-              label="Price Impact"
-              value={depositOption === 0 ? depositPriceImpact : withdrawPriceImpact}
-              unit="%"
-            />
+            {depositOption === 0 ? (
+              <TradeInfoItem
+                label="Price Impact"
+                value={depositPriceImpact}
+                unit="%"
+                color={Number(depositPriceImpact) > 3 ? 'red' : Number(depositPriceImpact) < 1 ? 'green' : undefined}
+              />
+            ) : (
+              <TradeInfoItem
+                label="Price Impact"
+                value={withdrawPriceImpact}
+                unit="%"
+                color={Number(withdrawPriceImpact) > 3 ? 'red' : Number(depositPriceImpact) < 1 ? 'green' : undefined}
+              />
+            )}
             {depositOption === 0 ? (
               <PrimaryButton
-                variant="contained"
-                style={{ marginTop: '8px' }}
+                variant={Number(depositPriceImpact) > 3 ? 'outlined' : 'contained'}
                 onClick={() => deposit()}
                 disabled={txLoading || !!maxCapError || !!depositError}
+                style={
+                  Number(depositPriceImpact) > 3
+                    ? { color: '#f5475c', backgroundColor: 'transparent', borderColor: '#f5475c', marginTop: '8px' }
+                    : { marginTop: '8px' }
+                }
               >
                 {!txLoading ? 'Deposit' : <CircularProgress color="primary" size="1.5rem" />}
               </PrimaryButton>
             ) : (
               <PrimaryButton
-                variant="contained"
-                style={{ marginTop: '8px' }}
+                variant={Number(withdrawPriceImpact) > 3 ? 'outlined' : 'contained'}
+                style={
+                  Number(withdrawPriceImpact) > 3
+                    ? { color: '#f5475c', backgroundColor: 'transparent', borderColor: '#f5475c', marginTop: '8px' }
+                    : { marginTop: '8px' }
+                }
                 onClick={() => withdraw()}
                 disabled={txLoading || !!withdrawError}
               >


### PR DESCRIPTION
# Task: Strategy price impact colors and button change

## Description
- Similar to trade page show price impact as green if below 1% and red color + red button if above 3% (video is ropsten)

https://user-images.githubusercontent.com/13340486/151072230-ed12d1fd-8f69-4f49-b468-28bcc76f986f.mov

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Added video recordings if it is a UI change
