### PR TITLE
fix: temporarily use contract short amount for closing until manual mints + sells are take into account

### DIFF
--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -594,18 +594,17 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
 
   useEffect(() => {
     if (!shortVaults.length) return
-    const calculatedShort = mintedDebt.plus(lpedSqueeth).plus(shortDebt)
+    // const calculatedShort = mintedDebt.plus(lpedSqueeth).plus(shortDebt)
     const contractShort = shortVaults.length && shortVaults[firstValidVault]?.shortAmount
 
-    console.log('calc short ' + calculatedShort)
-    console.log('contract short ' + contractShort)
-
-    if (!calculatedShort.isEqualTo(contractShort)) {
-      setFinalShortAmount(contractShort)
-    } else {
-      setFinalShortAmount(shortDebt)
-    }
-  }, [shortVaults?.length, mintedDebt.toString(), shortDebt.toString(), lpedSqueeth.toString(), firstValidVault])
+    // if (!calculatedShort.isEqualTo(contractShort)) {
+    //   setFinalShortAmount(contractShort)
+    // } else {
+    //   setFinalShortAmount(shortDebt)
+    // }
+    setFinalShortAmount(contractShort)
+  }, [shortVaults?.length, firstValidVault])
+  // }, [shortVaults?.length, mintedDebt.toString(), shortDebt.toString(), lpedSqueeth.toString(), firstValidVault])
 
   useEffect(() => {
     if (!open && shortVaults.length && shortVaults[firstValidVault].shortAmount.lt(amount)) {


### PR DESCRIPTION
# Task: Temporarily use contract short amount for closing until manual mints + sells are take into account

## Description
- Use the more conservative contract short amount value for close position on the trade page until manual mints + sells are taken into account because otherwise it is completely missing manual mints and sells for now

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
