### PR TITLE
feat: update crab explanations, warnings, payoff

### DIFF
--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -363,7 +363,7 @@ const TabComponent: React.FC = () => {
 const SqueethInfo: React.FC = () => {
   const classes = useStyles()
   const { actualTradeType } = useTrade()
-  const { fundingPerHalfHour, mark, index, impliedVol, currentImpliedFunding } = useController()
+  const { dailyHistoricalFunding, mark, index, impliedVol, currentImpliedFunding } = useController()
 
   const [showAdvanced, setShowAdvanced] = useState(false)
 
@@ -388,11 +388,13 @@ const SqueethInfo: React.FC = () => {
               <Typography color="textSecondary" variant="body2">
                 Historical Daily Funding
               </Typography>
-              <Tooltip title={Tooltips.Last30MinAvgFunding}>
+              <Tooltip
+                title={`Historical daily funding based on the last ${dailyHistoricalFunding.period} hours. Calculated using a ${dailyHistoricalFunding.period} hour TWAP of Mark - Index`}
+              >
                 <InfoIcon fontSize="small" className={classes.infoIcon} />
               </Tooltip>
             </div>
-            <Typography>{(fundingPerHalfHour * 100).toFixed(2) || 'loading'}%</Typography>
+            <Typography>{(dailyHistoricalFunding.funding * 100).toFixed(2) || 'loading'}%</Typography>
           </div>
           <div className={classes.infoItem}>
             <div className={classes.infoLabel}>

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -149,7 +149,7 @@ const Strategies: React.FC = () => {
               Crab automates a strategy that performs best in sideways markets. Based on current funding, crab would be
               profitable if ETH moves less than approximately <b>{(profitableMovePercent * 100).toFixed(2)}%</b> in
               either direction each day. Crab hedges daily, reducing risk of liquidations. Crab aims to be profitable in
-              USD terms. You earn squeeth without taking any view on if ETH will move up or down.
+              USD terms. You earn funding without taking any view on if ETH will move up or down.
               <a className={classes.link} href={Links.CrabFAQ} target="_blank" rel="noreferrer">
                 {' '}
                 Learn more.{' '}

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -96,7 +96,7 @@ const Strategies: React.FC = () => {
   const classes = useStyles()
   const { balance, address, selectWallet } = useWallet()
   const { maxCap, vault, collatRatio, timeAtLastHedge, profitableMovePercent } = useCrab()
-  const { index, currentImpliedFunding, fundingPerHalfHour } = useController()
+  const { index, currentImpliedFunding, dailyHistoricalFunding } = useController()
 
   useMemo(() => {
     if (selectedIdx === 0) return Vaults.ETHBull
@@ -171,9 +171,11 @@ const Strategies: React.FC = () => {
                     tooltip={`${Tooltips.StrategyEarnFunding}. ${Tooltips.CurrentImplFunding}`}
                   />
                   <StrategyInfoItem
-                    value={(fundingPerHalfHour * 100).toFixed(2)}
+                    value={(dailyHistoricalFunding.funding * 100).toFixed(2)}
                     label="Historical Daily Funding (%)"
-                    tooltip={`${Tooltips.StrategyEarnFunding}. ${Tooltips.Last30MinAvgFunding}`}
+                    tooltip={`${
+                      Tooltips.StrategyEarnFunding
+                    }. ${`Historical daily funding based on the last ${dailyHistoricalFunding.period} hours. Calculated using a ${dailyHistoricalFunding.period} hour TWAP of Mark - Index`}`}
                   />
                 </div>
                 <div className={classes.overview}>

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -148,8 +148,8 @@ const Strategies: React.FC = () => {
             <Typography variant="subtitle1" color="textSecondary" style={{ width: '60%', marginTop: '8px' }}>
               Crab automates a strategy that performs best in sideways markets. Based on current funding, crab would be
               profitable if ETH moves less than approximately <b>{(profitableMovePercent * 100).toFixed(2)}%</b> in
-              either direction each day. Crab hedges daily, reducing risk of liquidations. You earn squeeth without
-              taking any view on if ETH will move up or down.
+              either direction each day. Crab hedges daily, reducing risk of liquidations. Crab aims to be profitable in
+              USD terms. You earn squeeth without taking any view on if ETH will move up or down.
               <a className={classes.link} href={Links.CrabFAQ} target="_blank" rel="noreferrer">
                 {' '}
                 Learn more.{' '}

--- a/packages/frontend/src/components/Charts/ShortSqueethPayoff.tsx
+++ b/packages/frontend/src/components/Charts/ShortSqueethPayoff.tsx
@@ -6,6 +6,7 @@ import { Vaults } from '../../constants'
 import { getCrabVaultPayoff, getSqueethShortPayOffGraph } from '../../utils'
 
 const color0 = '#6df7e7'
+const color1 = '#6df7e7'
 const color14 = '#6d78f7'
 const color28 = '#F5B073'
 
@@ -110,6 +111,7 @@ const ShortSqueethPayoff: React.FC<{ ethPrice: number; collatRatio: number; vaul
 }) => {
   const [labels, setLabels] = useState<Array<number>>([])
   const [values0, setValues0] = useState<Array<string>>([])
+  const [values1, setValues1] = useState<Array<string | null>>([])
   const [values14, setValues14] = useState<Array<string | null>>([])
   const [values28, setValues28] = useState<Array<string | null>>([])
 
@@ -123,11 +125,14 @@ const ShortSqueethPayoff: React.FC<{ ethPrice: number; collatRatio: number; vaul
       setValues14(payout14)
       setValues28(payout28)
     } else if (vaultType === Vaults.CrabVault) {
-      const { ethPrices, payout0, payout14, payout28 } = getCrabVaultPayoff(ethPrice, collatRatio)
+      // const { ethPrices, payout0, payout14, payout28 } = getCrabVaultPayoff(ethPrice, collatRatio)
+      // setLabels(ethPrices)
+      // setValues0(payout0)
+      // setValues14(payout14)
+      // setValues28(payout28)
+      const { ethPrices, payout1 } = getSqueethShortPayOffGraph(ethPrice, collatRatio)
       setLabels(ethPrices)
-      setValues0(payout0)
-      setValues14(payout14)
-      setValues28(payout28)
+      setValues1(payout1)
     }
   }, [ethPrice, collatRatio])
 
@@ -175,9 +180,33 @@ const ShortSqueethPayoff: React.FC<{ ethPrice: number; collatRatio: number; vaul
     }
   }, [labels, values0, values14, values28])
 
+  const getCrabData = useCallback(() => {
+    return {
+      labels,
+      datasets: [
+        {
+          label: '1 day return',
+          data: values1,
+          fill: false,
+          borderColor: color1,
+          pointHoverBorderColor: color1,
+          pointHoverBackgroundColor: color1,
+          pointBackgroundColor: 'rgba(0, 0, 0, 0)',
+          pointBorderColor: 'rgba(0, 0, 0, 0)',
+          pointHoverRadius: 5,
+          pointHitRadius: 30,
+        },
+      ],
+    }
+  }, [labels, values1])
+
   return (
     <div style={{ width: '100%' }}>
-      <Line data={getData} type="line" height={300} width={400} options={chartOptions} />
+      {vaultType === Vaults.CrabVault ? (
+        <Line data={getCrabData} type="line" height={300} width={400} options={chartOptions} />
+      ) : (
+        <Line data={getData} type="line" height={300} width={400} options={chartOptions} />
+      )}
     </div>
   )
 }

--- a/packages/frontend/src/components/Strategies/Crab/StrategyInfo.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/StrategyInfo.tsx
@@ -107,7 +107,7 @@ export const StrategyInfo: React.FC = () => {
       <Typography variant="h5" color="primary" className={classes.title}>
         Payoff
       </Typography>
-      <ShortSqueethPayoff ethPrice={ethPrice.toNumber()} collatRatio={2} />
+      <ShortSqueethPayoff ethPrice={ethPrice.toNumber()} collatRatio={2} vaultType={Vaults.CrabVault} />
       <Typography variant="h5" color="primary" className={classes.title}>
         Steps
       </Typography>

--- a/packages/frontend/src/components/Strategies/Crab/StrategyInfo.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/StrategyInfo.tsx
@@ -101,7 +101,8 @@ export const StrategyInfo: React.FC = () => {
       </div>
       <Typography color="textSecondary" variant="subtitle1" className={classes.caption}>
         Based on current funding, crab strategy would be unprofitable if ETH moves more than the profit threshold of
-        approximately <b>{(profitableMovePercent * 100).toFixed(2)}%</b> in either direction each day.
+        approximately <b>{(profitableMovePercent * 100).toFixed(2)}%</b> in either direction each day. Crab aims to be
+        profitable in USD terms.
       </Typography>
       <Typography variant="h5" color="primary" className={classes.title}>
         Payoff
@@ -121,8 +122,11 @@ export const StrategyInfo: React.FC = () => {
         liquidation. Rebalancing based on large ETH price changes helps prevent a liquidation from occurring.
         <br /> <br />
         Based on current funding, crab strategy would be unprofitable if ETH moves more than approximately{' '}
-        {(profitableMovePercent * 100).toFixed(2)}% in either direction each day. If the Squeeth premium to ETH
-        increases, the strategy will incur a loss because it will be more expensive to close the position.
+        {(profitableMovePercent * 100).toFixed(2)}% in either direction each day. The implied funding rate at which you
+        deposit at impacts your profitability. Depositing at a high funding rate increases likelihood of profitability.
+        <br /> <br />
+        If the Squeeth premium to ETH increases, the strategy will incur a loss because it will be more expensive to
+        close the position. Crab aims to be profitable in USD terms.
         <a className={classes.link} href={Links.CrabFAQ} target="_blank" rel="noreferrer">
           {' '}
           Learn more.{' '}

--- a/packages/frontend/src/components/Strategies/Crab/StrategyInfo.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/StrategyInfo.tsx
@@ -107,7 +107,7 @@ export const StrategyInfo: React.FC = () => {
       <Typography variant="h5" color="primary" className={classes.title}>
         Payoff
       </Typography>
-      <ShortSqueethPayoff ethPrice={ethPrice.toNumber()} collatRatio={2} vaultType={Vaults.CrabVault} />
+      <ShortSqueethPayoff ethPrice={ethPrice.toNumber()} collatRatio={2} />
       <Typography variant="h5" color="primary" className={classes.title}>
         Steps
       </Typography>

--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -49,7 +49,7 @@ export enum Tooltips {
   Operator = 'The wrapper contract mints squeeth, deposits collateral and sells squeeth in single TX. Similarly it also buys back + burns squeeth and withdraws collateral in single TX',
   SellCloseAmount = 'Amount of oSQTH to buy',
   CurrentCollRatio = 'Collateral ratio for current short position',
-  SellOpenAmount = 'Minimum collateral amount is 7.5 ETH to ensure system solvency with sufficient liquidation incentive',
+  SellOpenAmount = 'Minimum collateral amount is 6.9 ETH to ensure system solvency with sufficient liquidation incentive',
   LiquidationPrice = 'Price of ETH when liquidation occurs.',
   InitialPremium = 'Initial payment you get for selling squeeth on Uniswap',
   BacktestDisclaimer = 'This is historical backtest data and does not show the actual performance of squeeth. See the FAQ to learn more.',
@@ -63,12 +63,12 @@ export enum Tooltips {
   ShortDebt = 'This is squeeth that you acquired and sold',
   TotalDebt = 'Debt of the vault',
   VaultLiquidations = 'The strategy is subject to liquidations if it goes below 150% collateral, but rebalancing based on large ETH price changes helps prevent a liquidation from occurring.',
-  CrabPnL = 'Expected total profit/ loss if you were to fully withdraw from the Crab Strategy. Includes price impact from trading on uniswap. Resets if you close your position.',
+  MinCrabPnL = 'This is your minimum PnL, as it takes into account slippage on Uniswap since the strategy uses flashswaps to deposit and withdraw',
   StrategyLiquidations = 'The strategy is subject to liquidations if it goes below 150% collateral, but rebalancing based on large ETH price changes helps prevent a liquidation from occurring.',
   StrategyShort = 'The amount of oSQTH the whole strategy is short',
   StrategyCollRatio = 'The collateralization ratio for the whole strategy',
   StrategyEarnFunding = 'You earn funding by depositing into the strategy',
-  StrategyProfitThreshold = 'Based on current funding, crab strategy would be unprofitable if ETH moves more than approximately the profit threshold in either direction each day.',
+  StrategyProfitThreshold = 'Based on current funding, crab strategy would be unprofitable if ETH moves more than the profit threshold in either direction each day.',
 }
 
 export enum Links {

--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -63,12 +63,12 @@ export enum Tooltips {
   ShortDebt = 'This is squeeth that you acquired and sold',
   TotalDebt = 'Debt of the vault',
   VaultLiquidations = 'The strategy is subject to liquidations if it goes below 150% collateral, but rebalancing based on large ETH price changes helps prevent a liquidation from occurring.',
-  MinCrabPnL = 'This is your minimum PnL, as it takes into account slippage on Uniswap since the strategy uses flashswaps to deposit and withdraw',
+  CrabPnL = 'Expected total profit/ loss if you were to fully withdraw from the Crab Strategy. Includes price impact from trading on uniswap. Resets if you close your position.',
   StrategyLiquidations = 'The strategy is subject to liquidations if it goes below 150% collateral, but rebalancing based on large ETH price changes helps prevent a liquidation from occurring.',
   StrategyShort = 'The amount of oSQTH the whole strategy is short',
   StrategyCollRatio = 'The collateralization ratio for the whole strategy',
   StrategyEarnFunding = 'You earn funding by depositing into the strategy',
-  StrategyProfitThreshold = 'Based on current funding, crab strategy would be unprofitable if ETH moves more than the profit threshold in either direction each day.',
+  StrategyProfitThreshold = 'Based on current funding, crab strategy would be unprofitable if ETH moves more than approximately the profit threshold in either direction each day.',
 }
 
 export enum Links {

--- a/packages/frontend/src/hooks/contracts/useController.ts
+++ b/packages/frontend/src/hooks/contracts/useController.ts
@@ -222,7 +222,7 @@ export const useController = () => {
     // return () => sub.unsubscribe()
   }, [web3, networkId, getIndex])
 
-  // Tries to get funding for the longest period available based on Uniswap storage slots, optimistically 24hrs, worst case 30min
+  // Tries to get funding for the longest period available based on Uniswap storage slots, optimistically 24hrs, worst case spot
   // TODO: get 24hr historical funding from the subgraph to have a value that isn't dynamic based on storage slots
   const getDailyHistoricalFunding = async () => {
     let index = new BigNumber(0)
@@ -236,6 +236,7 @@ export const useController = () => {
         //convert period from hours to seconds
         index = await getIndex(period * 3600)
         mark = await getMark(period * 3600)
+        isError = false
       } catch (error) {
         isError = true
       }
@@ -247,13 +248,6 @@ export const useController = () => {
       index = await getIndex(1)
       mark = await getMark(1)
     }
-    // try {
-    //   index = await getIndex(1800)
-    //   mark = await getMark(1800)
-    // } catch (error) {
-    //   index = await getIndex(1)
-    //   mark = await getMark(1)
-    // }
 
     if (index.isEqualTo(0)) {
       return { period: 0, funding: 0 }

--- a/packages/frontend/src/hooks/contracts/useController.ts
+++ b/packages/frontend/src/hooks/contracts/useController.ts
@@ -24,7 +24,7 @@ export const useController = () => {
   const [normFactor, setNormFactor] = useState(new BigNumber(1))
   const [mark, setMark] = useState(new BigNumber(0))
   const [index, setIndex] = useState(new BigNumber(0))
-  const [fundingPerHalfHour, setFundingPerHalfHour] = useState(0)
+  const [dailyHistoricalFunding, setDailyHistoricalFunding] = useState({ period: 0, funding: 0 })
   const [currentImpliedFunding, setCurrentImpliedFunding] = useState(0)
   const { controller, ethUsdcPool, weth, usdc } = useAddresses()
   const { getTwapSafe } = useOracle()
@@ -54,7 +54,7 @@ export const useController = () => {
 
   useEffect(() => {
     if (!contract) return
-    getFundingForHalfHour().then(setFundingPerHalfHour)
+    getDailyHistoricalFunding().then(setDailyHistoricalFunding)
     getCurrentImpliedFunding().then(setCurrentImpliedFunding)
   }, [address, contract])
 
@@ -222,21 +222,48 @@ export const useController = () => {
     // return () => sub.unsubscribe()
   }, [web3, networkId, getIndex])
 
-  const getFundingForHalfHour = async () => {
-    let index
-    let mark
-    try {
-      index = await getIndex(1800)
-      mark = await getMark(1800)
-    } catch (error) {
+  // Tries to get funding for the longest period available based on Uniswap storage slots, optimistically 24hrs, worst case 30min
+  // TODO: get 24hr historical funding from the subgraph to have a value that isn't dynamic based on storage slots
+  const getDailyHistoricalFunding = async () => {
+    let index = new BigNumber(0)
+    let mark = new BigNumber(0)
+    let period = 24
+    let isError = false
+
+    //start by trying 24hr twap, if fails try dividing by 2 until 45min minimum, fall back to spot otherwise
+    for (; period >= 0.75; period = period / 2) {
+      try {
+        //convert period from hours to seconds
+        index = await getIndex(period * 3600)
+        mark = await getMark(period * 3600)
+      } catch (error) {
+        isError = true
+      }
+      if (isError === false) {
+        break
+      }
+    }
+    if (index.isEqualTo(0) || mark.isEqualTo(0)) {
       index = await getIndex(1)
       mark = await getMark(1)
     }
+    // try {
+    //   index = await getIndex(1800)
+    //   mark = await getMark(1800)
+    // } catch (error) {
+    //   index = await getIndex(1)
+    //   mark = await getMark(1)
+    // }
+
     if (index.isEqualTo(0)) {
-      return 0
+      return { period: 0, funding: 0 }
     }
 
-    return Math.log(mark.dividedBy(index).toNumber()) / FUNDING_PERIOD
+    console.log('period ' + period)
+
+    const funding = Math.log(mark.dividedBy(index).toNumber()) / FUNDING_PERIOD
+
+    return { period: period, funding: funding }
   }
 
   const getCurrentImpliedFunding = async () => {
@@ -308,7 +335,7 @@ export const useController = () => {
     impliedVol,
     updateOperator,
     normFactor,
-    fundingPerHalfHour,
+    dailyHistoricalFunding,
     getDebtAmount,
     getShortAmountFromDebt,
     burnAndRedeem,

--- a/packages/frontend/src/utils/pricer.ts
+++ b/packages/frontend/src/utils/pricer.ts
@@ -384,6 +384,7 @@ function getShortParams(ethPrice: number, collatRatio: number) {
   const depositValue = initialCollat * ethPrice - squeethMark
 
   const cuNF0 = dailyNormFactor ** 0
+  const cuNF1 = dailyNormFactor ** 1
   const cuNF14 = dailyNormFactor ** 14
   const cuNF28 = dailyNormFactor ** 28
   const getEthPrices = () => {
@@ -404,6 +405,7 @@ function getShortParams(ethPrice: number, collatRatio: number) {
     initialCollat,
     depositValue,
     cuNF0,
+    cuNF1,
     cuNF14,
     cuNF28,
     ethPrices: getEthPrices(),
@@ -411,13 +413,17 @@ function getShortParams(ethPrice: number, collatRatio: number) {
 }
 
 export function getSqueethShortPayOffGraph(ethPrice: number, collatRatio: number) {
-  const { markRatio, initialCollat, depositValue, cuNF0, cuNF14, cuNF28, ethPrices } = getShortParams(
+  const { markRatio, initialCollat, depositValue, cuNF0, cuNF1, cuNF14, cuNF28, ethPrices } = getShortParams(
     ethPrice,
     collatRatio,
   )
 
   const payout0 = ethPrices.map((p) => {
     return (((-1 * cuNF0 * p ** 2 * markRatio + initialCollat * p) / depositValue - 1) * 100).toFixed(2)
+  })
+
+  const payout1 = ethPrices.map((p) => {
+    return (((-1 * cuNF1 * p ** 2 * markRatio + initialCollat * p) / depositValue - 1) * 100).toFixed(2)
   })
 
   const payout14 = ethPrices.map((p) => {
@@ -431,6 +437,7 @@ export function getSqueethShortPayOffGraph(ethPrice: number, collatRatio: number
   return {
     ethPrices,
     payout0,
+    payout1,
     payout14,
     payout28,
   }

--- a/packages/frontend/src/utils/pricer.ts
+++ b/packages/frontend/src/utils/pricer.ts
@@ -397,6 +397,16 @@ function getShortParams(ethPrice: number, collatRatio: number) {
         return inc
       })
   }
+  const getCrabEthPrices = () => {
+    let inc = Math.floor(ethPrice / 2)
+    return Array(100)
+      .fill(0)
+      .map((_, i) => {
+        if (i === 0) return inc
+        inc += 30
+        return inc
+      })
+  }
 
   return {
     squeethIndex,
@@ -409,11 +419,12 @@ function getShortParams(ethPrice: number, collatRatio: number) {
     cuNF14,
     cuNF28,
     ethPrices: getEthPrices(),
+    crabEthPrices: getCrabEthPrices(),
   }
 }
 
 export function getSqueethShortPayOffGraph(ethPrice: number, collatRatio: number) {
-  const { markRatio, initialCollat, depositValue, cuNF0, cuNF1, cuNF14, cuNF28, ethPrices } = getShortParams(
+  const { markRatio, initialCollat, depositValue, cuNF0, cuNF1, cuNF14, cuNF28, ethPrices, crabEthPrices } = getShortParams(
     ethPrice,
     collatRatio,
   )
@@ -422,7 +433,7 @@ export function getSqueethShortPayOffGraph(ethPrice: number, collatRatio: number
     return (((-1 * cuNF0 * p ** 2 * markRatio + initialCollat * p) / depositValue - 1) * 100).toFixed(2)
   })
 
-  const payout1 = ethPrices.map((p) => {
+  const payout1 = crabEthPrices.map((p) => {
     return (((-1 * cuNF1 * p ** 2 * markRatio + initialCollat * p) / depositValue - 1) * 100).toFixed(2)
   })
 


### PR DESCRIPTION
# Task: Update crab explanations, warnings, payoff

## Description
- Show longest historical daily funding possible from Uniswap twap 
- Update copy re usd profitability and implications around depositing with low funding 
- Add warning if users are trying to deposit and current implied funding is less than 75% of historical daily funding 
- Update payoff diagram to 1 day return (note reverting this for this PR, can be included in another PR when we figure out how to better zoom in on the chart to display the return)


https://user-images.githubusercontent.com/13340486/151259420-2a058b31-b3cb-4f2f-a823-97085fa1522d.mov



Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Added video recordings if it is a UI change
