### PR TITLE
feat: update risks seciton and add high vol warning on long side

### DIFF
--- a/packages/frontend/src/components/Charts/LongChart.tsx
+++ b/packages/frontend/src/components/Charts/LongChart.tsx
@@ -263,7 +263,10 @@ export function LongChart() {
             Squeeth smart contracts have been audited by Trail of Bits, Akira, and Sherlock. However, smart contracts
             are experimental technology and we encourage caution only risking funds you can afford to lose.
             <br /> <br />
-            If ETH goes down considerably, you may lose some or all of your initial investment.
+            Profitability also depends on the price you enter and exit, which is dependent on implied volatility (the
+            premium of squeeth to ETH). If the squeeth premium to ETH decreases, without a change in ETH price, a long
+            position will incur a loss because it is not worth as much ETH. If ETH goes down considerably, you may lose
+            some or all of your initial investment.
             <a className={classes.header} href={Links.GitBook} target="_blank" rel="noreferrer">
               {' '}
               Learn more.{' '}

--- a/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
@@ -107,7 +107,7 @@ const CrabTrade: React.FC<CrabTradeType> = ({ maxCap, depositedAmount }) => {
         depositError = 'Deposits and withdraws available after the hedge auction'
         withdrawError = 'Deposits and withdraws available after the hedge auction'
       }
-      if (currentImpliedFunding < 0.75 * dailyHistoricalFunding.funding) {
+      if (currentImpliedFunding <= 0.75 * dailyHistoricalFunding.funding) {
         warning = `Current implied funding is 75% lower than the last ${dailyHistoricalFunding.period} hours. Consider if you want to deposit now or later`
       }
     }
@@ -264,7 +264,7 @@ const CrabTrade: React.FC<CrabTradeType> = ({ maxCap, depositedAmount }) => {
             )}
             {depositOption === 0 ? (
               <PrimaryButton
-                variant={Number(depositPriceImpact) > 3 ? 'outlined' : 'contained'}
+                variant={Number(depositPriceImpact) > 3 || !!warning ? 'outlined' : 'contained'}
                 onClick={() => deposit()}
                 disabled={txLoading || !!depositError}
                 style={

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -15,6 +15,7 @@ import { PrimaryButton } from '@components/Button'
 import { PrimaryInput } from '@components/Input/PrimaryInput'
 import { UniswapIframe } from '@components/Modal/UniswapIframe'
 import { TradeSettings } from '@components/TradeSettings'
+import { useController } from '@hooks/contracts/useController'
 import Confirmed, { ConfirmType } from '../Confirmed'
 import TradeInfoItem from '../TradeInfoItem'
 import UniswapData from '../UniswapData'
@@ -239,11 +240,13 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
   const altTradeAmount = new BigNumber(altAmountInputValue)
   const { selectWallet, connected } = useWallet()
   const { squeethAmount, longSqthBal, isShort } = usePositions()
+  const { dailyHistoricalFunding, currentImpliedFunding } = useController()
 
   let openError: string | undefined
   // let closeError: string | undefined
   let existingShortError: string | undefined
   let priceImpactWarning: string | undefined
+  let highVolError: string | undefined
 
   if (connected) {
     // if (longSqthBal.lt(amount)) {
@@ -257,6 +260,9 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
     }
     if (new BigNumber(quote.priceImpact).gt(3)) {
       priceImpactWarning = 'High Price Impact'
+    }
+    if (currentImpliedFunding >= 1.75 * dailyHistoricalFunding.funding) {
+      highVolError = `Current implied funding is 75% higher than the last ${dailyHistoricalFunding.period} hours. Consider if you want to purchase now or later`
     }
   }
 
@@ -320,7 +326,7 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
                 onActionClicked={() => handleOpenDualInputUpdate(balance.toString(), InputType.ETH)}
                 unit="ETH"
                 convertedValue={amount.times(ethPrice).toFixed(2).toLocaleString()}
-                error={!!existingShortError || !!priceImpactWarning || !!openError}
+                error={!!existingShortError || !!priceImpactWarning || !!openError || !!highVolError}
                 isLoading={inputQuoteLoading}
                 hint={
                   openError ? (
@@ -329,6 +335,8 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
                     existingShortError
                   ) : priceImpactWarning ? (
                     priceImpactWarning
+                  ) : highVolError ? (
+                    highVolError
                   ) : (
                     <div className={classes.hint}>
                       <span>{`Balance ${balance.toFixed(4)}`}</span>
@@ -360,6 +368,8 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
                     existingShortError
                   ) : priceImpactWarning ? (
                     priceImpactWarning
+                  ) : highVolError ? (
+                    highVolError
                   ) : (
                     <div className={classes.hint}>
                       <span className={classes.hintTextContainer}>
@@ -414,12 +424,12 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
                   </PrimaryButton>
                 ) : (
                   <PrimaryButton
-                    variant={longOpenPriceImpactErrorState ? 'outlined' : 'contained'}
+                    variant={longOpenPriceImpactErrorState || !!highVolError ? 'outlined' : 'contained'}
                     onClick={transact}
                     className={classes.amountInput}
                     disabled={!!buyLoading || !!openError || !!existingShortError}
                     style={
-                      longOpenPriceImpactErrorState
+                      longOpenPriceImpactErrorState || !!highVolError
                         ? { width: '300px', color: '#f5475c', backgroundColor: 'transparent', borderColor: '#f5475c' }
                         : { width: '300px' }
                     }

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -233,8 +233,6 @@ const OpenShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeComp
   }, [shortVaults?.length, firstValidVault])
 
   const { existingCollatPercent } = useVaultData(Number(vaultId))
-  console.log('fvv ' + Number(vaultId))
-  console.log('collat % ' + existingCollatPercent)
 
   useEffect(() => {
     if (!open) return

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -34,6 +34,7 @@ import TradeInfoItem from '@components/Trade/TradeInfoItem'
 import UniswapData from '@components/Trade/UniswapData'
 import { MIN_COLLATERAL_AMOUNT } from '../../../constants'
 import { PositionType } from '../../../types'
+import { useVaultData } from '@hooks/useVaultData'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -206,7 +207,7 @@ const OpenShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeComp
   } = useTrade()
   const amount = new BigNumber(amountInputValue)
   const collateral = new BigNumber(collateralInput)
-  const { firstValidVault, existingCollatPercent, squeethAmount: shortSqueethAmount, isLong } = usePositions()
+  const { firstValidVault, squeethAmount: shortSqueethAmount, isLong } = usePositions()
   const { vaults: shortVaults, loading: vaultIDLoading } = useVaultManager()
 
   const [vaultId, setVaultId] = useState(shortVaults.length ? shortVaults[firstValidVault].id : 0)
@@ -230,6 +231,10 @@ const OpenShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeComp
 
     setVaultId(shortVaults[firstValidVault].id)
   }, [shortVaults?.length, firstValidVault])
+
+  const { existingCollatPercent } = useVaultData(Number(vaultId))
+  console.log('fvv ' + Number(vaultId))
+  console.log('collat % ' + existingCollatPercent)
 
   useEffect(() => {
     if (!open) return
@@ -581,7 +586,6 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
     positionType,
     shortVaults,
     firstValidVault,
-    existingCollatPercent,
     squeethAmount: shortSqueethAmount,
     isLong,
     lpedSqueeth,
@@ -620,6 +624,8 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
 
     setVaultId(shortVaults[firstValidVault].id)
   }, [shortVaults?.length])
+
+  const { existingCollatPercent } = useVaultData(Number(vaultId))
 
   useEffect(() => {
     if (!open) return


### PR DESCRIPTION
# Task: feat: update risks seciton and add high vol warning on long side

## Description
- Update risks copy and add warning for high vol on long side if current vol is 75% greater than historical vol
- Update low vol error UI on crab trade 
- Update collat ratio on short / trade card

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
