### PR TITLE
make preferred as false

### DIFF
--- a/packages/frontend/src/context/wallet.tsx
+++ b/packages/frontend/src/context/wallet.tsx
@@ -178,7 +178,7 @@ const WalletProvider: React.FC = ({ children }) => {
 
         wallets: [
           { walletName: 'metamask', preferred: true },
-          { walletName: 'coinbase', preferred: true },
+          { walletName: 'coinbase', preferred: false },
           {
             walletName: 'walletLink',
             rpcUrl: RPC_URL,


### PR DESCRIPTION
# Task:

Making coinbase wallet to default to false

## Description

Right now when i try to connect to walletlink, it takes us to coinbase wallet.
( cannot reproduce this on local host. only seen this happen on squeeth.com)
So making the preferred as false to mitigate that issue

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

tested locally to see that i was able to connect to both wallet link and coinbase wallet

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
