### PR TITLE
fix: reduce number of calls made to infura/alchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ packages/hardhat/*.txt
 packages/hardhat/artifacts*
 packages/hardhat/typechain*
 # ignore localhost, but keep other deployment record on git
-packages/hardhat/deployments/localhost 
+packages/hardhat/deployments/localhost
 packages/react-app/src/contracts/*
 !packages/react-app/src/contracts/external_contracts.js
 packages/hardhat/cache*
@@ -48,3 +48,6 @@ yarn-error.log*
 
 # Local Netlify folder
 .netlify
+
+# asdf config
+**/.tool-versions

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -36,6 +36,7 @@
     "kaktana-react-lightweight-charts": "^2.0.0",
     "markdown-to-jsx": "^7.1.5",
     "next": "^12.0.7",
+    "particule": "^0.0.4",
     "react": "17.0.2",
     "react-chartjs-2": "^2.11.1",
     "react-cookie": "^4.1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -37,7 +37,6 @@
     "kaktana-react-lightweight-charts": "^2.0.0",
     "markdown-to-jsx": "^7.1.5",
     "next": "^12.0.7",
-    "particule": "^0.0.4",
     "react": "17.0.2",
     "react-chartjs-2": "^2.11.1",
     "react-cookie": "^4.1.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -33,6 +33,7 @@
     "framer-motion": "^5.3.3",
     "graphql": "^16.1.0",
     "gray-matter": "^4.0.3",
+    "jotai": "^1.5.3",
     "kaktana-react-lightweight-charts": "^2.0.0",
     "markdown-to-jsx": "^7.1.5",
     "next": "^12.0.7",

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -8,7 +8,7 @@ import ExpandLessIcon from '@material-ui/icons/NavigateBefore'
 import ExpandMoreIcon from '@material-ui/icons/NavigateNext'
 import Image from 'next/image'
 import { useState } from 'react'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 import squeethTokenSymbol from '../public/images/Squeeth.svg'
 import { PrimaryButton } from '@components/Button'
@@ -371,12 +371,12 @@ const TabComponent: React.FC = () => {
 const SqueethInfo: React.FC = () => {
   const classes = useStyles()
   const { actualTradeType } = useTrade()
-  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
-  const mark = useGetAtom(markAtom)
-  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
-  const impliedVol = useGetAtom(impliedVolAtom)
-  const index = useGetAtom(indexAtom)
-  const normFactor = useGetAtom(normFactorAtom)
+  const dailyHistoricalFunding = useAtom(dailyHistoricalFundingAtom)[0]
+  const mark = useAtom(markAtom)[0]
+  const currentImpliedFunding = useAtom(currentImpliedFundingAtom)[0]
+  const impliedVol = useAtom(impliedVolAtom)[0]
+  const index = useAtom(indexAtom)[0]
+  const normFactor = useAtom(normFactorAtom)[0]
 
   const [showAdvanced, setShowAdvanced] = useState(false)
 

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -8,6 +8,7 @@ import ExpandLessIcon from '@material-ui/icons/NavigateBefore'
 import ExpandMoreIcon from '@material-ui/icons/NavigateNext'
 import Image from 'next/image'
 import { useState } from 'react'
+import { useGetAtom } from "particule"
 
 import squeethTokenSymbol from '../public/images/Squeeth.svg'
 import { PrimaryButton } from '@components/Button'
@@ -24,7 +25,14 @@ import { Vaults } from '../src/constants'
 import { Tooltips } from '@constants/enums'
 import { useRestrictUser } from '@context/restrict-user'
 import { TradeProvider, useTrade } from '@context/trade'
-import { useController } from '@hooks/contracts/useController'
+import {
+  indexAtom,
+  markAtom,
+  currentImpliedFundingAtom,
+  impliedVolAtom,
+  dailyHistoricalFundingAtom,
+  normFactorAtom
+} from '@hooks/contracts/useController'
 import { TradeType } from '../src/types'
 import { toTokenAmount } from '@utils/calculations'
 
@@ -363,7 +371,12 @@ const TabComponent: React.FC = () => {
 const SqueethInfo: React.FC = () => {
   const classes = useStyles()
   const { actualTradeType } = useTrade()
-  const { dailyHistoricalFunding, mark, index, impliedVol, currentImpliedFunding, normFactor } = useController()
+  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
+  const mark = useGetAtom(markAtom)
+  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
+  const impliedVol = useGetAtom(impliedVolAtom)
+  const index = useGetAtom(indexAtom)
+  const normFactor = useGetAtom(normFactorAtom)
 
   const [showAdvanced, setShowAdvanced] = useState(false)
 

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -8,7 +8,7 @@ import ExpandLessIcon from '@material-ui/icons/NavigateBefore'
 import ExpandMoreIcon from '@material-ui/icons/NavigateNext'
 import Image from 'next/image'
 import { useState } from 'react'
-import { useGetAtom } from "particule"
+import { useGetAtom } from 'particule'
 
 import squeethTokenSymbol from '../public/images/Squeeth.svg'
 import { PrimaryButton } from '@components/Button'
@@ -31,7 +31,7 @@ import {
   currentImpliedFundingAtom,
   impliedVolAtom,
   dailyHistoricalFundingAtom,
-  normFactorAtom
+  normFactorAtom,
 } from '@hooks/contracts/useController'
 import { TradeType } from '../src/types'
 import { toTokenAmount } from '@utils/calculations'

--- a/packages/frontend/pages/lp.tsx
+++ b/packages/frontend/pages/lp.tsx
@@ -14,9 +14,10 @@ import RestrictionInfo from '@components/RestrictionInfo'
 import { LPProvider } from '@context/lp'
 import { useRestrictUser } from '@context/restrict-user'
 import { TradeProvider } from '@context/trade'
-import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
 import { useWorldContext } from '@context/world'
 import { SqueethTab, SqueethTabs } from '@components/Tabs'
+import { poolAtom } from '@hooks/contracts/useSqueethPool'
+import { useGetAtom } from 'particule'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -82,8 +83,8 @@ export function LPCalculator() {
   const classes = useStyles()
   const { isRestricted } = useRestrictUser()
   const { ethPrice } = useWorldContext()
-
   const [lpType, setLpType] = useState(0)
+  const pool = useGetAtom(poolAtom);
 
   return (
     <div>

--- a/packages/frontend/pages/lp.tsx
+++ b/packages/frontend/pages/lp.tsx
@@ -16,7 +16,6 @@ import { useRestrictUser } from '@context/restrict-user'
 import { TradeProvider } from '@context/trade'
 import { useWorldContext } from '@context/world'
 import { SqueethTab, SqueethTabs } from '@components/Tabs'
-import { useGetAtom } from 'particule'
 
 const useStyles = makeStyles((theme) =>
   createStyles({

--- a/packages/frontend/pages/lp.tsx
+++ b/packages/frontend/pages/lp.tsx
@@ -16,7 +16,6 @@ import { useRestrictUser } from '@context/restrict-user'
 import { TradeProvider } from '@context/trade'
 import { useWorldContext } from '@context/world'
 import { SqueethTab, SqueethTabs } from '@components/Tabs'
-import { poolAtom } from '@hooks/contracts/useSqueethPool'
 import { useGetAtom } from 'particule'
 
 const useStyles = makeStyles((theme) =>
@@ -84,7 +83,6 @@ export function LPCalculator() {
   const { isRestricted } = useRestrictUser()
   const { ethPrice } = useWorldContext()
   const [lpType, setLpType] = useState(0)
-  const pool = useGetAtom(poolAtom);
 
   return (
     <div>

--- a/packages/frontend/pages/positions.tsx
+++ b/packages/frontend/pages/positions.tsx
@@ -5,18 +5,19 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
 import clsx from 'clsx'
+import { useGetAtom } from "particule"
 
 import { LPTable } from '@components/Lp/LPTable'
 import Nav from '@components/Nav'
 import History from '@components/Trade/History'
 import { PositionType } from '../src/types/'
 import { Tooltips } from '../src/constants'
-import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
+import { poolAtom } from '@hooks/contracts/useSqueethPool'
 import { useWorldContext } from '@context/world'
 import { usePnL } from '@hooks/usePositions'
 import { useVaultLiquidations } from '@hooks/contracts/useLiquidations'
 import { toTokenAmount } from '@utils/calculations'
-import { useController } from '../src/hooks/contracts/useController'
+import { indexAtom } from '../src/hooks/contracts/useController'
 import { CrabProvider } from '@context/crabStrategy'
 import { useCrabPosition } from '@hooks/useCrabPosition'
 import { useWallet } from '@context/wallet'
@@ -153,7 +154,7 @@ export function Positions() {
     longUnrealizedPNL,
   } = usePnL()
 
-  const { pool } = useSqueethPool()
+  const pool = useGetAtom(poolAtom)
 
   const { oSqueethBal } = useWorldContext()
   const { address } = useWallet()
@@ -175,7 +176,7 @@ export function Positions() {
     activePositions,
   } = usePositions()
 
-  const { index } = useController()
+  const index = useGetAtom(indexAtom)
   const {
     depositedEth,
     depositedUsd,

--- a/packages/frontend/pages/positions.tsx
+++ b/packages/frontend/pages/positions.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
 import clsx from 'clsx'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 import { LPTable } from '@components/Lp/LPTable'
 import Nav from '@components/Nav'
@@ -154,7 +154,7 @@ export function Positions() {
     longUnrealizedPNL,
   } = usePnL()
 
-  const pool = useGetAtom(poolAtom)
+  const pool = useAtom(poolAtom)[0]
 
   const { oSqueethBal } = useWorldContext()
   const { address } = useWallet()
@@ -176,7 +176,7 @@ export function Positions() {
     activePositions,
   } = usePositions()
 
-  const index = useGetAtom(indexAtom)
+  const index = useAtom(indexAtom)[0]
   const {
     depositedEth,
     depositedUsd,

--- a/packages/frontend/pages/positions.tsx
+++ b/packages/frontend/pages/positions.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
 import clsx from 'clsx'
-import { useGetAtom } from "particule"
+import { useGetAtom } from 'particule'
 
 import { LPTable } from '@components/Lp/LPTable'
 import Nav from '@components/Nav'

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -9,11 +9,7 @@ import { useWallet } from '@context/wallet'
 import { CrabProvider, useCrab } from '@context/crabStrategy'
 import { Typography, Tab, Tabs } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
-import {
-  currentImpliedFundingAtom,
-  indexAtom,
-  dailyHistoricalFundingAtom,
-} from '@hooks/contracts/useController'
+import { currentImpliedFundingAtom, indexAtom, dailyHistoricalFundingAtom } from '@hooks/contracts/useController'
 import { toTokenAmount } from '@utils/calculations'
 import BigNumber from 'bignumber.js'
 import React, { useMemo, useState } from 'react'

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -13,7 +13,7 @@ import {
   currentImpliedFundingAtom,
   fundingPerHalfHourAtom,
   indexAtom,
-  dailyHistoricalFundingAtom
+  dailyHistoricalFundingAtom,
 } from '@hooks/contracts/useController'
 import { toTokenAmount } from '@utils/calculations'
 import BigNumber from 'bignumber.js'

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -9,7 +9,12 @@ import { useWallet } from '@context/wallet'
 import { CrabProvider, useCrab } from '@context/crabStrategy'
 import { Typography, Tab, Tabs } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
-import { useController } from '@hooks/contracts/useController'
+import {
+  currentImpliedFundingAtom,
+  fundingPerHalfHourAtom,
+  indexAtom,
+  dailyHistoricalFundingAtom
+} from '@hooks/contracts/useController'
 import { toTokenAmount } from '@utils/calculations'
 import BigNumber from 'bignumber.js'
 import React, { useMemo, useState } from 'react'
@@ -19,6 +24,7 @@ import Image from 'next/image'
 import bull from '../public/images/bull.gif'
 import bear from '../public/images/bear.gif'
 import CrabTrade from '@components/Strategies/Crab/CrabTrade'
+import { useGetAtom } from 'particule'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -96,7 +102,10 @@ const Strategies: React.FC = () => {
   const classes = useStyles()
   const { balance, address, selectWallet } = useWallet()
   const { maxCap, vault, collatRatio, timeAtLastHedge, profitableMovePercent } = useCrab()
-  const { index, currentImpliedFunding, dailyHistoricalFunding } = useController()
+  const index = useGetAtom(indexAtom)
+  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
+  const fundingPerHalfHour = useGetAtom(fundingPerHalfHourAtom)
+  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
 
   useMemo(() => {
     if (selectedIdx === 0) return Vaults.ETHBull

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -11,7 +11,6 @@ import { Typography, Tab, Tabs } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import {
   currentImpliedFundingAtom,
-  fundingPerHalfHourAtom,
   indexAtom,
   dailyHistoricalFundingAtom,
 } from '@hooks/contracts/useController'
@@ -104,7 +103,6 @@ const Strategies: React.FC = () => {
   const { maxCap, vault, collatRatio, timeAtLastHedge, profitableMovePercent } = useCrab()
   const index = useGetAtom(indexAtom)
   const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
-  const fundingPerHalfHour = useGetAtom(fundingPerHalfHourAtom)
   const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
 
   useMemo(() => {

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -23,7 +23,7 @@ import Image from 'next/image'
 import bull from '../public/images/bull.gif'
 import bear from '../public/images/bear.gif'
 import CrabTrade from '@components/Strategies/Crab/CrabTrade'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -101,9 +101,9 @@ const Strategies: React.FC = () => {
   const classes = useStyles()
   const { balance, address, selectWallet } = useWallet()
   const { maxCap, vault, collatRatio, timeAtLastHedge, profitableMovePercent } = useCrab()
-  const index = useGetAtom(indexAtom)
-  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
-  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
+  const index = useAtom(indexAtom)[0]
+  const currentImpliedFunding = useAtom(currentImpliedFundingAtom)[0]
+  const dailyHistoricalFunding = useAtom(dailyHistoricalFundingAtom)[0]
 
   useMemo(() => {
     if (selectedIdx === 0) return Vaults.ETHBull

--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -26,7 +26,7 @@ import { Vault_vault } from '../../src/queries/squeeth/__generated__/Vault'
 import { PositionType } from '../../src/types'
 import { useRestrictUser } from '@context/restrict-user'
 import { useWallet } from '@context/wallet'
-import { useController } from '@hooks/contracts/useController'
+import { normFactorAtom, useController } from '@hooks/contracts/useController'
 import { useVaultLiquidations } from '@hooks/contracts/useLiquidations'
 import { useVaultData } from '@hooks/useVaultData'
 import { useWorldContext } from '@context/world'
@@ -34,6 +34,7 @@ import { CollateralStatus, Vault } from '../../src/types'
 import { squeethClient } from '@utils/apollo-client'
 import { getCollatPercentStatus, toTokenAmount } from '@utils/calculations'
 import { LinkButton } from '@components/Button'
+import { useGetAtom } from 'particule'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -225,13 +226,13 @@ const Component: React.FC = () => {
     getCollatRatioAndLiqPrice,
     getDebtAmount,
     getShortAmountFromDebt,
-    normFactor,
     depositCollateral,
     withdrawCollateral,
     openDepositAndMint,
     burnAndRedeem,
     getTwapEthPrice,
   } = useController()
+  const normFactor = useGetAtom(normFactorAtom);
   const { balance, address, connected, networkId } = useWallet()
   const { vid } = router.query
   const { liquidations } = useVaultLiquidations(Number(vid))

--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -34,7 +34,7 @@ import { CollateralStatus, Vault } from '../../src/types'
 import { squeethClient } from '@utils/apollo-client'
 import { getCollatPercentStatus, toTokenAmount } from '@utils/calculations'
 import { LinkButton } from '@components/Button'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -232,7 +232,7 @@ const Component: React.FC = () => {
     burnAndRedeem,
     getTwapEthPrice,
   } = useController()
-  const normFactor = useGetAtom(normFactorAtom)
+  const normFactor = useAtom(normFactorAtom)[0]
   const { balance, address, connected, networkId } = useWallet()
   const { vid } = router.query
   const { liquidations } = useVaultLiquidations(Number(vid))

--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -232,7 +232,7 @@ const Component: React.FC = () => {
     burnAndRedeem,
     getTwapEthPrice,
   } = useController()
-  const normFactor = useGetAtom(normFactorAtom);
+  const normFactor = useGetAtom(normFactorAtom)
   const { balance, address, connected, networkId } = useWallet()
   const { vid } = router.query
   const { liquidations } = useVaultLiquidations(Number(vid))

--- a/packages/frontend/src/components/Lp/GetSqueeth.tsx
+++ b/packages/frontend/src/components/Lp/GetSqueeth.tsx
@@ -3,7 +3,7 @@ import { createStyles, makeStyles } from '@material-ui/core/styles'
 import BigNumber from 'bignumber.js'
 import { motion } from 'framer-motion'
 import React, { useEffect, useMemo, useState } from 'react'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 import { MIN_COLLATERAL_AMOUNT, Tooltips } from '../../constants'
 import { LPActions, OBTAIN_METHOD, useLPState } from '@context/lp'
@@ -74,7 +74,7 @@ const Mint: React.FC = () => {
   const { vaults: shortVaults, loading: vaultIDLoading } = useVaultManager()
   const { getWSqueethPositionValue } = useSqueethPool()
   const { openDepositAndMint, getShortAmountFromDebt } = useController()
-  const normalizationFactor = useGetAtom(normFactorAtom)
+  const normalizationFactor = useAtom(normFactorAtom)[0]
   const { dispatch } = useLPState()
 
   const [mintAmount, setMintAmount] = useState(new BigNumber(0))

--- a/packages/frontend/src/components/Lp/GetSqueeth.tsx
+++ b/packages/frontend/src/components/Lp/GetSqueeth.tsx
@@ -3,11 +3,12 @@ import { createStyles, makeStyles } from '@material-ui/core/styles'
 import BigNumber from 'bignumber.js'
 import { motion } from 'framer-motion'
 import React, { useEffect, useMemo, useState } from 'react'
+import { useGetAtom } from 'particule'
 
 import { MIN_COLLATERAL_AMOUNT, Tooltips } from '../../constants'
 import { LPActions, OBTAIN_METHOD, useLPState } from '@context/lp'
 import { useWallet } from '@context/wallet'
-import { useController } from '@hooks/contracts/useController'
+import { normFactorAtom, useController } from '@hooks/contracts/useController'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
 import { useWorldContext } from '@context/world'
 import { usePositions } from '@context/positions'
@@ -72,7 +73,8 @@ const Mint: React.FC = () => {
   const { existingCollatPercent, existingCollat, firstValidVault } = usePositions()
   const { vaults: shortVaults, loading: vaultIDLoading } = useVaultManager()
   const { getWSqueethPositionValue } = useSqueethPool()
-  const { normFactor: normalizationFactor, openDepositAndMint, getShortAmountFromDebt } = useController()
+  const { openDepositAndMint, getShortAmountFromDebt } = useController()
+  const normalizationFactor = useGetAtom(normFactorAtom)
   const { dispatch } = useLPState()
 
   const [mintAmount, setMintAmount] = useState(new BigNumber(0))

--- a/packages/frontend/src/components/Lp/SqueethInfo.tsx
+++ b/packages/frontend/src/components/Lp/SqueethInfo.tsx
@@ -48,9 +48,9 @@ const useStyles = makeStyles((theme) =>
 
 const SqueethInfo: React.FC = () => {
   const classes = useStyles()
-  const mark = useGetAtom(markAtom);
-  const index = useGetAtom(indexAtom);
-  const impliedVol = useGetAtom(impliedVolAtom);
+  const mark = useGetAtom(markAtom)
+  const index = useGetAtom(indexAtom)
+  const impliedVol = useGetAtom(impliedVolAtom)
   const { getWSqueethPositionValue, getWSqueethPositionValueInETH } = useSqueethPool()
   const { address } = useWallet()
 

--- a/packages/frontend/src/components/Lp/SqueethInfo.tsx
+++ b/packages/frontend/src/components/Lp/SqueethInfo.tsx
@@ -10,7 +10,7 @@ import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
 import { toTokenAmount } from '@utils/calculations'
 import LPPosition from './LPPosition'
 import { useWallet } from '@context/wallet'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -48,9 +48,9 @@ const useStyles = makeStyles((theme) =>
 
 const SqueethInfo: React.FC = () => {
   const classes = useStyles()
-  const mark = useGetAtom(markAtom)
-  const index = useGetAtom(indexAtom)
-  const impliedVol = useGetAtom(impliedVolAtom)
+  const mark = useAtom(markAtom)[0]
+  const index = useAtom(indexAtom)[0]
+  const impliedVol = useAtom(impliedVolAtom)[0]
   const { getWSqueethPositionValue, getWSqueethPositionValueInETH } = useSqueethPool()
   const { address } = useWallet()
 

--- a/packages/frontend/src/components/Lp/SqueethInfo.tsx
+++ b/packages/frontend/src/components/Lp/SqueethInfo.tsx
@@ -5,11 +5,12 @@ import InfoIcon from '@material-ui/icons/InfoOutlined'
 import React from 'react'
 
 import { Tooltips } from '@constants/enums'
-import { useController } from '@hooks/contracts/useController'
+import { impliedVolAtom, indexAtom, markAtom } from '@hooks/contracts/useController'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
 import { toTokenAmount } from '@utils/calculations'
 import LPPosition from './LPPosition'
 import { useWallet } from '@context/wallet'
+import { useGetAtom } from 'particule'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -47,7 +48,9 @@ const useStyles = makeStyles((theme) =>
 
 const SqueethInfo: React.FC = () => {
   const classes = useStyles()
-  const { mark, index, impliedVol } = useController()
+  const mark = useGetAtom(markAtom);
+  const index = useGetAtom(indexAtom);
+  const impliedVol = useGetAtom(impliedVolAtom);
   const { getWSqueethPositionValue, getWSqueethPositionValueInETH } = useSqueethPool()
   const { address } = useWallet()
 

--- a/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
@@ -17,7 +17,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import CrabPosition from './CrabPosition'
 import { readyAtom } from '@hooks/contracts/useSqueethPool'
 import { currentImpliedFundingAtom, dailyHistoricalFundingAtom } from '@hooks/contracts/useController'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -83,9 +83,9 @@ const CrabTrade: React.FC<CrabTradeType> = ({ maxCap, depositedAmount }) => {
   } = useCrab()
   const { minCurrentUsd, minPnL, loading } = useCrabPosition(address || '')
   const { isRestricted } = useRestrictUser()
-  const ready = useGetAtom(readyAtom)
-  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
-  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
+  const ready = useAtom(readyAtom)[0]
+  const dailyHistoricalFunding = useAtom(dailyHistoricalFundingAtom)[0]
+  const currentImpliedFunding = useAtom(currentImpliedFundingAtom)[0]
 
   const { depositError, warning, withdrawError } = useMemo(() => {
     let depositError: string | undefined

--- a/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTrade.tsx
@@ -15,8 +15,9 @@ import { toTokenAmount } from '@utils/calculations'
 import BigNumber from 'bignumber.js'
 import React, { useEffect, useMemo, useState } from 'react'
 import CrabPosition from './CrabPosition'
-import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
-import { useController } from '@hooks/contracts/useController'
+import { readyAtom } from '@hooks/contracts/useSqueethPool'
+import { currentImpliedFundingAtom, dailyHistoricalFundingAtom } from '@hooks/contracts/useController'
+import { useGetAtom } from 'particule'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -82,8 +83,9 @@ const CrabTrade: React.FC<CrabTradeType> = ({ maxCap, depositedAmount }) => {
   } = useCrab()
   const { minCurrentUsd, minPnL, loading } = useCrabPosition(address || '')
   const { isRestricted } = useRestrictUser()
-  const { ready } = useSqueethPool()
-  const { dailyHistoricalFunding, currentImpliedFunding } = useController()
+  const ready = useGetAtom(readyAtom)
+  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
+  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
 
   const { depositError, warning, withdrawError } = useMemo(() => {
     let depositError: string | undefined

--- a/packages/frontend/src/components/Trade/History.tsx
+++ b/packages/frontend/src/components/Trade/History.tsx
@@ -49,7 +49,7 @@ const History: React.FC = () => {
   const { transactions } = useTransactionHistory()
   const { networkId } = useWallet()
   const { ethPrice } = useWorldContext()
-  const normalizationFactor = useGetAtom(normFactorAtom);
+  const normalizationFactor = useGetAtom(normFactorAtom)
   const classes = useStyles()
   const { getUsdAmt } = useUsdAmount()
 

--- a/packages/frontend/src/components/Trade/History.tsx
+++ b/packages/frontend/src/components/Trade/History.tsx
@@ -8,7 +8,7 @@ import { normFactorAtom } from '@hooks/contracts/useController'
 import { useWorldContext } from '@context/world'
 import { useTransactionHistory } from '@hooks/useTransactionHistory'
 import { useUsdAmount } from '@hooks/useUsdAmount'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 const useStyles = makeStyles((theme) =>
   createStyles({
     container: {
@@ -49,7 +49,7 @@ const History: React.FC = () => {
   const { transactions } = useTransactionHistory()
   const { networkId } = useWallet()
   const { ethPrice } = useWorldContext()
-  const normalizationFactor = useGetAtom(normFactorAtom)
+  const normalizationFactor = useAtom(normFactorAtom)[0]
   const classes = useStyles()
   const { getUsdAmt } = useUsdAmount()
 

--- a/packages/frontend/src/components/Trade/History.tsx
+++ b/packages/frontend/src/components/Trade/History.tsx
@@ -4,10 +4,11 @@ import OpenInNewIcon from '@material-ui/icons/OpenInNew'
 import { EtherscanPrefix } from '../../constants'
 import { TransactionType } from '@constants/enums'
 import { useWallet } from '@context/wallet'
-import { useController } from '@hooks/contracts/useController'
+import { normFactorAtom } from '@hooks/contracts/useController'
 import { useWorldContext } from '@context/world'
 import { useTransactionHistory } from '@hooks/useTransactionHistory'
 import { useUsdAmount } from '@hooks/useUsdAmount'
+import { useGetAtom } from 'particule'
 const useStyles = makeStyles((theme) =>
   createStyles({
     container: {
@@ -48,7 +49,7 @@ const History: React.FC = () => {
   const { transactions } = useTransactionHistory()
   const { networkId } = useWallet()
   const { ethPrice } = useWorldContext()
-  const { normFactor: normalizationFactor } = useController()
+  const normalizationFactor = useGetAtom(normFactorAtom);
   const classes = useStyles()
   const { getUsdAmt } = useUsdAmount()
 

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -2,6 +2,7 @@ import { CircularProgress, createStyles, makeStyles, Typography } from '@materia
 import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt'
 import BigNumber from 'bignumber.js'
 import React, { useCallback, useEffect, useState } from 'react'
+import { useGetAtom } from 'particule'
 
 import { InputType, Links } from '../../../constants'
 import { useTrade } from '@context/trade'
@@ -15,7 +16,7 @@ import { PrimaryButton } from '@components/Button'
 import { PrimaryInput } from '@components/Input/PrimaryInput'
 import { UniswapIframe } from '@components/Modal/UniswapIframe'
 import { TradeSettings } from '@components/TradeSettings'
-import { useController } from '@hooks/contracts/useController'
+import { currentImpliedFundingAtom, dailyHistoricalFundingAtom } from '@hooks/contracts/useController'
 import Confirmed, { ConfirmType } from '../Confirmed'
 import TradeInfoItem from '../TradeInfoItem'
 import UniswapData from '../UniswapData'
@@ -239,7 +240,8 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
   const altTradeAmount = new BigNumber(altAmountInputValue)
   const { selectWallet, connected } = useWallet()
   const { squeethAmount, longSqthBal, isShort } = usePositions()
-  const { dailyHistoricalFunding, currentImpliedFunding } = useController()
+  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
+  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
 
   let openError: string | undefined
   // let closeError: string | undefined

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -2,7 +2,7 @@ import { CircularProgress, createStyles, makeStyles, Typography } from '@materia
 import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt'
 import BigNumber from 'bignumber.js'
 import React, { useCallback, useEffect, useState } from 'react'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 import { InputType, Links } from '../../../constants'
 import { useTrade } from '@context/trade'
@@ -240,8 +240,8 @@ const OpenLong: React.FC<BuyProps> = ({ balance, setTradeCompleted, activeStep =
   const altTradeAmount = new BigNumber(altAmountInputValue)
   const { selectWallet, connected } = useWallet()
   const { squeethAmount, longSqthBal, isShort } = usePositions()
-  const dailyHistoricalFunding = useGetAtom(dailyHistoricalFundingAtom)
-  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom)
+  const dailyHistoricalFunding = useAtom(dailyHistoricalFundingAtom)[0]
+  const currentImpliedFunding = useAtom(currentImpliedFundingAtom)[0]
 
   let openError: string | undefined
   // let closeError: string | undefined

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -13,12 +13,13 @@ import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt'
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined'
 import BigNumber from 'bignumber.js'
 import React, { useCallback, useEffect, useState } from 'react'
+import { useGetAtom } from 'particule'
 
 import { CloseType, Tooltips, Links } from '@constants/enums'
 import { useTrade } from '@context/trade'
 import { useWallet } from '@context/wallet'
 import { useWorldContext } from '@context/world'
-import { useController } from '@hooks/contracts/useController'
+import { normFactorAtom, useController } from '@hooks/contracts/useController'
 import useShortHelper from '@hooks/contracts/useShortHelper'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
 import { useVaultManager } from '@hooks/contracts/useVaultManager'
@@ -35,6 +36,7 @@ import UniswapData from '@components/Trade/UniswapData'
 import { MIN_COLLATERAL_AMOUNT } from '../../../constants'
 import { PositionType } from '../../../types'
 import { useVaultData } from '@hooks/useVaultData'
+
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -192,7 +194,8 @@ const OpenShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeComp
   const classes = useStyles()
   const { openShort } = useShortHelper()
   const { getWSqueethPositionValue } = useSqueethPool()
-  const { updateOperator, normFactor: normalizationFactor, getShortAmountFromDebt, getDebtAmount } = useController()
+  const { updateOperator, getShortAmountFromDebt, getDebtAmount } = useController()
+  const normalizationFactor = useGetAtom(normFactorAtom);
   const { selectWallet, connected } = useWallet()
   const { shortHelper } = useAddresses()
 
@@ -564,7 +567,8 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
   const classes = useStyles()
   const { closeShort } = useShortHelper()
   const { getWSqueethPositionValue } = useSqueethPool()
-  const { updateOperator, normFactor: normalizationFactor, getShortAmountFromDebt, getDebtAmount } = useController()
+  const { updateOperator, getShortAmountFromDebt, getDebtAmount } = useController()
+  const normalizationFactor = useGetAtom(normFactorAtom);
   const { shortHelper } = useAddresses()
 
   const { selectWallet, connected } = useWallet()

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -37,7 +37,6 @@ import { MIN_COLLATERAL_AMOUNT } from '../../../constants'
 import { PositionType } from '../../../types'
 import { useVaultData } from '@hooks/useVaultData'
 
-
 const useStyles = makeStyles((theme) =>
   createStyles({
     cardTitle: {
@@ -195,7 +194,7 @@ const OpenShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeComp
   const { openShort } = useShortHelper()
   const { getWSqueethPositionValue } = useSqueethPool()
   const { updateOperator, getShortAmountFromDebt, getDebtAmount } = useController()
-  const normalizationFactor = useGetAtom(normFactorAtom);
+  const normalizationFactor = useGetAtom(normFactorAtom)
   const { selectWallet, connected } = useWallet()
   const { shortHelper } = useAddresses()
 
@@ -568,7 +567,7 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
   const { closeShort } = useShortHelper()
   const { getWSqueethPositionValue } = useSqueethPool()
   const { updateOperator, getShortAmountFromDebt, getDebtAmount } = useController()
-  const normalizationFactor = useGetAtom(normFactorAtom);
+  const normalizationFactor = useGetAtom(normFactorAtom)
   const { shortHelper } = useAddresses()
 
   const { selectWallet, connected } = useWallet()

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -13,7 +13,7 @@ import ArrowRightAltIcon from '@material-ui/icons/ArrowRightAlt'
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined'
 import BigNumber from 'bignumber.js'
 import React, { useCallback, useEffect, useState } from 'react'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 import { CloseType, Tooltips, Links } from '@constants/enums'
 import { useTrade } from '@context/trade'
@@ -194,7 +194,7 @@ const OpenShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeComp
   const { openShort } = useShortHelper()
   const { getWSqueethPositionValue } = useSqueethPool()
   const { updateOperator, getShortAmountFromDebt, getDebtAmount } = useController()
-  const normalizationFactor = useGetAtom(normFactorAtom)
+  const normalizationFactor = useAtom(normFactorAtom)[0]
   const { selectWallet, connected } = useWallet()
   const { shortHelper } = useAddresses()
 
@@ -567,7 +567,7 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
   const { closeShort } = useShortHelper()
   const { getWSqueethPositionValue } = useSqueethPool()
   const { updateOperator, getShortAmountFromDebt, getDebtAmount } = useController()
-  const normalizationFactor = useGetAtom(normFactorAtom)
+  const normalizationFactor = useAtom(normFactorAtom)[0]
   const { shortHelper } = useAddresses()
 
   const { selectWallet, connected } = useWallet()

--- a/packages/frontend/src/context/crabStrategy.tsx
+++ b/packages/frontend/src/context/crabStrategy.tsx
@@ -11,7 +11,7 @@ import abi from '../abis/crabStrategy.json'
 import { fromTokenAmount, toTokenAmount } from '@utils/calculations'
 import { useTokenBalance } from '@hooks/contracts/useTokenBalance'
 import db from '@utils/firestore'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 type CrabStrategyType = {
   loading: boolean
@@ -94,8 +94,8 @@ const CrabProvider: React.FC = ({ children }) => {
   const { web3, address, handleTransaction, networkId } = useWallet()
   const { crabStrategy } = useAddresses()
   const { getVault, getCollatRatioAndLiqPrice } = useController()
-  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom);
-  const index = useGetAtom(indexAtom);
+  const currentImpliedFunding = useAtom(currentImpliedFundingAtom)[0]
+  const index = useAtom(indexAtom)[0]
   const { getSellQuote, getBuyQuote, ready } = useSqueethPool()
 
   const [contract, setContract] = useState<Contract>()

--- a/packages/frontend/src/context/crabStrategy.tsx
+++ b/packages/frontend/src/context/crabStrategy.tsx
@@ -5,12 +5,13 @@ import { BIG_ZERO } from '../constants'
 import { useWallet } from './wallet'
 import { useAddresses } from '@hooks/useAddress'
 import { useSqueethPool } from '@hooks/contracts/useSqueethPool'
-import { useController } from '@hooks/contracts/useController'
+import { currentImpliedFundingAtom, indexAtom, useController } from '@hooks/contracts/useController'
 import { Contract } from 'web3-eth-contract'
 import abi from '../abis/crabStrategy.json'
 import { fromTokenAmount, toTokenAmount } from '@utils/calculations'
 import { useTokenBalance } from '@hooks/contracts/useTokenBalance'
 import db from '@utils/firestore'
+import { useGetAtom } from 'particule'
 
 type CrabStrategyType = {
   loading: boolean
@@ -92,7 +93,9 @@ const useCrab = () => useContext(crabContext)
 const CrabProvider: React.FC = ({ children }) => {
   const { web3, address, handleTransaction, networkId } = useWallet()
   const { crabStrategy } = useAddresses()
-  const { getVault, getCollatRatioAndLiqPrice, currentImpliedFunding, index } = useController()
+  const { getVault, getCollatRatioAndLiqPrice } = useController()
+  const currentImpliedFunding = useGetAtom(currentImpliedFundingAtom);
+  const index = useGetAtom(indexAtom);
   const { getSellQuote, getBuyQuote, ready } = useSqueethPool()
 
   const [contract, setContract] = useState<Contract>()

--- a/packages/frontend/src/hooks/contracts/useController.ts
+++ b/packages/frontend/src/hooks/contracts/useController.ts
@@ -22,7 +22,6 @@ const getMultiplier = (type: Vaults) => {
 export const normFactorAtom = atom(new BigNumber(1))
 export const markAtom = atom(new BigNumber(0))
 export const indexAtom = atom(new BigNumber(0))
-export const fundingPerHalfHourAtom = atom(0)
 export const currentImpliedFundingAtom = atom(0)
 export const impliedVolAtom = atom((get: any) => {
   const mark = get(markAtom)
@@ -43,7 +42,6 @@ export const useController = () => {
   const [normFactor, setNormFactor] = useAtom(normFactorAtom)
   const [mark, setMark] = useAtom(markAtom)
   const [index, setIndex] = useAtom(indexAtom)
-  const [fundingPerHalfHour, setFundingPerHalfHour] = useAtom(fundingPerHalfHourAtom)
   const [currentImpliedFunding, setCurrentImpliedFunding] = useAtom(currentImpliedFundingAtom)
   const [dailyHistoricalFunding, setDailyHistoricalFunding] = useAtom(dailyHistoricalFundingAtom)
 

--- a/packages/frontend/src/hooks/contracts/useController.ts
+++ b/packages/frontend/src/hooks/contracts/useController.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Contract } from 'web3-eth-contract'
-import { atom, useAtom } from "particule"
+import { atom, useAtom } from 'jotai'
 
 import abi from '../../abis/controller.json'
 import { FUNDING_PERIOD, INDEX_SCALE, SWAP_EVENT_TOPIC, Vaults, OSQUEETH_DECIMALS, TWAP_PERIOD } from '../../constants'

--- a/packages/frontend/src/hooks/contracts/useShortHelper.ts
+++ b/packages/frontend/src/hooks/contracts/useShortHelper.ts
@@ -10,14 +10,14 @@ import { fromTokenAmount, toTokenAmount } from '@utils/calculations'
 import { useAddresses } from '../useAddress'
 import { normFactorAtom } from './useController'
 import { useSqueethPool } from './useSqueethPool'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 export const useShortHelper = () => {
   const { web3, address, handleTransaction } = useWallet()
   const [contract, setContract] = useState<Contract>()
 
   const { getSellParam, getBuyParam } = useSqueethPool()
-  const normalizationFactor = useGetAtom(normFactorAtom);
+  const normalizationFactor = useAtom(normFactorAtom)[0]
   const { shortHelper } = useAddresses()
 
   useEffect(() => {

--- a/packages/frontend/src/hooks/contracts/useShortHelper.ts
+++ b/packages/frontend/src/hooks/contracts/useShortHelper.ts
@@ -8,15 +8,16 @@ import { Vaults, WETH_DECIMALS, OSQUEETH_DECIMALS } from '../../constants'
 import { useWallet } from '@context/wallet'
 import { fromTokenAmount, toTokenAmount } from '@utils/calculations'
 import { useAddresses } from '../useAddress'
-import { useController } from './useController'
+import { normFactorAtom } from './useController'
 import { useSqueethPool } from './useSqueethPool'
+import { useGetAtom } from 'particule'
 
 export const useShortHelper = () => {
   const { web3, address, handleTransaction } = useWallet()
   const [contract, setContract] = useState<Contract>()
 
   const { getSellParam, getBuyParam } = useSqueethPool()
-  const { normFactor: normalizationFactor } = useController()
+  const normalizationFactor = useGetAtom(normFactorAtom);
   const { shortHelper } = useAddresses()
 
   useEffect(() => {

--- a/packages/frontend/src/hooks/contracts/useSqueethPool.ts
+++ b/packages/frontend/src/hooks/contracts/useSqueethPool.ts
@@ -13,11 +13,20 @@ import { fromTokenAmount, parseSlippageInput, toTokenAmount } from '@utils/calcu
 import { useAddresses } from '../useAddress'
 import useUniswapTicks from '../useUniswapTicks'
 import { useWorldContext } from '@context/world'
+import { atom, useAtom } from 'particule'
 
 // const NETWORK_QUOTE_GAS_OVERRIDE: { [chainId: number]: number } = {
 //   [Networks.ARBITRUM_RINKEBY]: 6_000_000,
 // }
 // const DEFAULT_GAS_QUOTE = 2_000_000
+
+export const poolAtom = atom<Pool | undefined>(undefined)
+export const wethTokenAtom = atom<Token | undefined>(undefined)
+export const squeethTokenAtom = atom<Token | undefined>(undefined)
+export const squeethInitialPriceAtom = atom(new BigNumber(0))
+export const squeethPriceAtom = atom(new BigNumber(0))
+export const wethPriceAtom = atom(new BigNumber(0))
+export const readyAtom = atom(false)
 
 /**
  * Hook to interact with WETH contract
@@ -25,13 +34,13 @@ import { useWorldContext } from '@context/world'
 export const useSqueethPool = () => {
   const [squeethContract, setSqueethContract] = useState<Contract>()
   const [swapRouterContract, setSwapRouterContract] = useState<Contract>()
-  const [pool, setPool] = useState<Pool>()
-  const [wethToken, setWethToken] = useState<Token>()
-  const [squeethToken, setSqueethToken] = useState<Token>()
-  const [squeethInitialPrice, setSqueethInitialPrice] = useState<BigNumber>(new BigNumber(0))
-  const [squeethPrice, setSqueethPrice] = useState<BigNumber>(new BigNumber(0))
-  const [wethPrice, setWethPrice] = useState<BigNumber>(new BigNumber(0))
-  const [ready, setReady] = useState(false)
+  const [pool, setPool] = useAtom(poolAtom)
+  const [wethToken, setWethToken] = useAtom(wethTokenAtom)
+  const [squeethToken, setSqueethToken] = useAtom(squeethTokenAtom)
+  const [squeethInitialPrice, setSqueethInitialPrice] = useAtom(squeethInitialPriceAtom)
+  const [squeethPrice, setSqueethPrice] = useAtom(squeethPriceAtom)
+  const [wethPrice, setWethPrice] = useAtom(wethPriceAtom)
+  const [ready, setReady] = useAtom(readyAtom)
   // const [tvl, setTVL] = useState(0)
   const { ethPrice } = useWorldContext()
 

--- a/packages/frontend/src/hooks/contracts/useSqueethPool.ts
+++ b/packages/frontend/src/hooks/contracts/useSqueethPool.ts
@@ -23,6 +23,7 @@ import { atom, useAtom } from 'jotai'
 export const poolAtom = atom<Pool | undefined>(undefined)
 export const wethTokenAtom = atom<Token | undefined>(undefined)
 export const squeethTokenAtom = atom<Token | undefined>(undefined)
+export const poolTokensAtom = atom<any>({})
 export const squeethInitialPriceAtom = atom(new BigNumber(0))
 export const squeethPriceAtom = atom(new BigNumber(0))
 export const wethPriceAtom = atom(new BigNumber(0))
@@ -37,6 +38,7 @@ export const useSqueethPool = () => {
   const [pool, setPool] = useAtom(poolAtom)
   const [wethToken, setWethToken] = useAtom(wethTokenAtom)
   const [squeethToken, setSqueethToken] = useAtom(squeethTokenAtom)
+  const [poolTokens, setPoolTokens] = useAtom(poolTokensAtom)
   const [squeethInitialPrice, setSqueethInitialPrice] = useAtom(squeethInitialPriceAtom)
   const [squeethPrice, setSqueethPrice] = useAtom(squeethPriceAtom)
   const [wethPrice, setWethPrice] = useAtom(wethPriceAtom)
@@ -130,6 +132,11 @@ export const useSqueethPool = () => {
     )
 
     if (isMounted) {
+      setPoolTokens({
+        pool,
+        wethToken: isWethToken0 ? TokenA : TokenB,
+        squeethToken: isWethToken0 ? TokenB : TokenA,
+      })
       setPool(pool)
       setWethToken(isWethToken0 ? TokenA : TokenB)
       setSqueethToken(isWethToken0 ? TokenB : TokenA)
@@ -328,6 +335,7 @@ export const useSqueethPool = () => {
       if (!squeethAmount || !pool) return emptyState
 
       try {
+        const { wethToken, squeethToken } = poolTokens
         //WETH is input token, squeeth is output token. I'm using WETH to buy Squeeth
         const route = new Route([pool], wethToken!, squeethToken!)
         //getting the amount of ETH I need to put in to get an exact amount of squeeth I inputted out
@@ -364,6 +372,7 @@ export const useSqueethPool = () => {
     if (!ETHAmount || !pool) return emptyState
 
     try {
+      const { wethToken, squeethToken } = poolTokens
       //WETH is input token, squeeth is output token. I'm using WETH to buy Squeeth
       const route = new Route([pool], wethToken!, squeethToken!)
       //getting the amount of squeeth I'd get out for putting in an exact amount of ETH
@@ -398,6 +407,7 @@ export const useSqueethPool = () => {
       if (!squeethAmount || !pool) return emptyState
 
       try {
+        const { wethToken, squeethToken } = poolTokens
         //squeeth is input token, WETH is output token. I'm selling squeeth for WETH
         const route = new Route([pool], squeethToken!, wethToken!)
         //getting the amount of ETH I'd receive for inputting the amount of squeeth I want to sell
@@ -433,6 +443,7 @@ export const useSqueethPool = () => {
     if (!ETHAmount || !pool) return emptyState
 
     try {
+      const { wethToken, squeethToken } = poolTokens
       //squeeth is input token, WETH is output token. I'm selling squeeth for WETH
       const route = new Route([pool], squeethToken!, wethToken!)
       //getting the amount of squeeth I'd need to sell to receive my desired amount of ETH

--- a/packages/frontend/src/hooks/contracts/useSqueethPool.ts
+++ b/packages/frontend/src/hooks/contracts/useSqueethPool.ts
@@ -13,7 +13,7 @@ import { fromTokenAmount, parseSlippageInput, toTokenAmount } from '@utils/calcu
 import { useAddresses } from '../useAddress'
 import useUniswapTicks from '../useUniswapTicks'
 import { useWorldContext } from '@context/world'
-import { atom, useAtom } from 'particule'
+import { atom, useAtom } from 'jotai'
 
 // const NETWORK_QUOTE_GAS_OVERRIDE: { [chainId: number]: number } = {
 //   [Networks.ARBITRUM_RINKEBY]: 6_000_000,

--- a/packages/frontend/src/hooks/useETHPrice.ts
+++ b/packages/frontend/src/hooks/useETHPrice.ts
@@ -1,7 +1,8 @@
 import BigNumber from 'bignumber.js'
 import { useCallback, useEffect, useState } from 'react'
+import { useGetAtom } from 'particule'
 
-import { useController } from './contracts/useController'
+import { indexAtom } from './contracts/useController'
 import { toTokenAmount } from '@utils/calculations'
 import { useIntervalAsync } from './useIntervalAsync'
 
@@ -13,7 +14,7 @@ import { useIntervalAsync } from './useIntervalAsync'
  */
 export const useETHPrice = (refetchIntervalSec = 30): BigNumber => {
   const [price, setPrice] = useState(new BigNumber(0))
-  const { index } = useController()
+  const index = useGetAtom(indexAtom)
 
   const updatePrice = useCallback(async () => {
     let newPrice: BigNumber

--- a/packages/frontend/src/hooks/useETHPrice.ts
+++ b/packages/frontend/src/hooks/useETHPrice.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { useCallback, useEffect, useState } from 'react'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 import { indexAtom } from './contracts/useController'
 import { toTokenAmount } from '@utils/calculations'
@@ -14,7 +14,7 @@ import { useIntervalAsync } from './useIntervalAsync'
  */
 export const useETHPrice = (refetchIntervalSec = 30): BigNumber => {
   const [price, setPrice] = useState(new BigNumber(0))
-  const index = useGetAtom(indexAtom)
+  const index = useAtom(indexAtom)[0]
 
   const updatePrice = useCallback(async () => {
     let newPrice: BigNumber

--- a/packages/frontend/src/hooks/usePositions.ts
+++ b/packages/frontend/src/hooks/usePositions.ts
@@ -16,10 +16,11 @@ import { toTokenAmount } from '@utils/calculations'
 import { squeethClient } from '@utils/apollo-client'
 
 import { useSqueethPool } from './contracts/useSqueethPool'
-import { useController } from './contracts/useController'
+import { indexAtom } from './contracts/useController'
 import { useAddresses } from './useAddress'
 import { calcDollarShortUnrealizedpnl, calcETHCollateralPnl, calcDollarLongUnrealizedpnl } from '../lib/pnl'
 import { BIG_ZERO } from '../constants/'
+import { useAtom } from 'jotai'
 
 export const usePnL = () => {
   const [ethCollateralPnl, setEthCollateralPnl] = useState(BIG_ZERO)
@@ -36,7 +37,7 @@ export const usePnL = () => {
     firstValidVault,
     existingCollat,
   } = usePositions()
-  const { index } = useController()
+  const [index] = useAtom(indexAtom)
 
   // const { ethPrice } = useWorldContext()
   const { ready, getSellQuote, getBuyQuote } = useSqueethPool()

--- a/packages/frontend/src/hooks/usePositions.ts
+++ b/packages/frontend/src/hooks/usePositions.ts
@@ -14,6 +14,7 @@ import { VaultHistory } from '../queries/squeeth/__generated__/VaultHistory'
 import { NFTManagers } from '../types'
 import { toTokenAmount } from '@utils/calculations'
 import { squeethClient } from '@utils/apollo-client'
+
 import { useSqueethPool } from './contracts/useSqueethPool'
 import { useController } from './contracts/useController'
 import { useAddresses } from './useAddress'

--- a/packages/frontend/src/hooks/useVaultData.ts
+++ b/packages/frontend/src/hooks/useVaultData.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/client'
 import BigNumber from 'bignumber.js'
 import { useEffect, useState } from 'react'
-import { useGetAtom } from 'particule'
+import { useAtom } from 'jotai'
 
 import { Vault } from '../types'
 import { OSQUEETH_DECIMALS } from '../constants'
@@ -22,7 +22,7 @@ export const useVaultData = (vid: number) => {
   const [isVaultLoading, setVaultLoading] = useState(true)
 
   const { getCollatRatioAndLiqPrice } = useController()
-  const normFactor = useGetAtom(normFactorAtom);
+  const normFactor = useAtom(normFactorAtom)[0]
   const { address, connected, networkId } = useWallet()
 
   const { data, loading: isDataLoading } = useQuery<{ vault: Vault_vault }>(VAULT_QUERY, {

--- a/packages/frontend/src/hooks/useVaultData.ts
+++ b/packages/frontend/src/hooks/useVaultData.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@apollo/client'
 import BigNumber from 'bignumber.js'
 import { useEffect, useState } from 'react'
+import { useGetAtom } from 'particule'
 
 import { Vault } from '../types'
 import { OSQUEETH_DECIMALS } from '../constants'
@@ -8,7 +9,7 @@ import { VAULT_QUERY } from '@queries/squeeth/vaultsQuery'
 import { Vault_vault } from '@queries/squeeth/__generated__/Vault'
 
 import { useWallet } from '@context/wallet'
-import { useController } from '@hooks/contracts/useController'
+import { useController, normFactorAtom } from '@hooks/contracts/useController'
 import { squeethClient } from '@utils/apollo-client'
 import { toTokenAmount } from '@utils/calculations'
 
@@ -20,7 +21,8 @@ export const useVaultData = (vid: number) => {
   const [collatPercent, setCollatPercent] = useState(0)
   const [isVaultLoading, setVaultLoading] = useState(true)
 
-  const { getCollatRatioAndLiqPrice, normFactor } = useController()
+  const { getCollatRatioAndLiqPrice } = useController()
+  const normFactor = useGetAtom(normFactorAtom);
   const { address, connected, networkId } = useWallet()
 
   const { data, loading: isDataLoading } = useQuery<{ vault: Vault_vault }>(VAULT_QUERY, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3804,16 +3804,13 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-assemblyscript@0.19.10, "assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#v0.6":
-  version "0.6.0"
-  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#3ed76a97f05335504166fce1653da75f4face28f"
+assemblyscript@0.19.10:
+  version "0.19.10"
+  resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.19.10.tgz#7ede6d99c797a219beb4fa4614c3eab9e6343c8e"
+  integrity sha512-HavcUBXB3mBTRGJcpvaQjmnmaqKHBGREjSPNsIvnAk2f9dj78y4BkMaSSdvBQYWcDDzsHQjyUC8stICFkD1Odg==
   dependencies:
-    "@protobufjs/utf8" "^1.1.0"
-    binaryen "77.0.0-nightly.20190407"
-    glob "^7.1.3"
+    binaryen "101.0.0-nightly.20210723"
     long "^4.0.0"
-    opencollective-postinstall "^2.0.0"
-    source-map-support "^0.5.11"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -4630,10 +4627,10 @@ binary-install-raw@0.0.13:
     rimraf "^3.0.2"
     tar "^6.1.0"
 
-binaryen@77.0.0-nightly.20190407:
-  version "77.0.0-nightly.20190407"
-  resolved "https://registry.npmjs.org/binaryen/-/binaryen-77.0.0-nightly.20190407.tgz#fbe4f8ba0d6bd0809a84eb519d2d5b5ddff3a7d1"
-  integrity sha512-1mxYNvQ0xywMe582K7V6Vo2zzhZZxMTeGHH8aE/+/AND8f64D8Q1GThVY3RVRwGY/4p+p95ccw9Xbw2ovFXRIg==
+binaryen@101.0.0-nightly.20210723:
+  version "101.0.0-nightly.20210723"
+  resolved "https://registry.yarnpkg.com/binaryen/-/binaryen-101.0.0-nightly.20210723.tgz#b6bb7f3501341727681a03866c0856500eec3740"
+  integrity sha512-eioJNqhHlkguVSbblHOtLqlhtC882SOEPKmNFZaDuz1hzQjolxZ+eu3/kaS10n3sGPONsIZsO7R9fR00UyhEUA==
 
 bind-decorator@^1.0.11:
   version "1.0.11"
@@ -10460,6 +10457,11 @@ jest-worker@27.0.0-next.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jotai@^1.5.3:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.6.0.tgz#81412756dab42fcb712530fba512e5e43bd0de15"
+  integrity sha512-J/+aD9R1XDcNeY8drg/y/I47eUivQ13HGmLmA33w95SvJJLBStSF5WxYrmLgbuWcDC6MpRecF3g/GBchPJNcZg==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
@@ -12784,11 +12786,6 @@ open@^7.4.2:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
-
-opencollective-postinstall@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 optimism@^0.16.1:
   version "0.16.1"
@@ -15135,18 +15132,18 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.11, source-map-support@^0.5.17:
-  version "0.5.21"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-support@^0.5.13:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.17:
+  version "0.5.21"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
# Task:
https://github.com/opynfinance/squeeth-monorepo/issues/11

## Description

Looks like calling `useController()` in many different places is causing repeat API calls to Infura/Alchemy. This PR attempts to reduce the number of API calls by reducing the number of `useController()` calls.

Ideally this alone would fix issue 11, but it alone cannot. I think there are two places where the API calls really skyrocket from `useController()` - inside `packages/frontend/src/hooks/usePositions.ts` there are two function `usePositions` and `useShortPositions`. Replacing the `const { getDebtAmount } = useController()` with a dummy method reduces a lot of API calls, which leads me to suspect that if the `getDebtAmount` method could be extracted out from `useController()`, a lot of API calls could be removed.

Fixes # (issue)
https://github.com/opynfinance/squeeth-monorepo/issues/11

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Start the frontend for `main` branch and record the number of Infura/Alchemy API calls.

Start the frontend for `issue-11` branch and open the networks tab to compare the new number of Infura/Alchemy API calls. There should be fewer API calls.

Please reproduce on your end as this is my first PR for the Squeeth FE and I am not so familiar with the codebase. Thanks!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
