### PR TITLE
fix: short PnL calc

### DIFF
--- a/packages/frontend/src/lib/pnl.ts
+++ b/packages/frontend/src/lib/pnl.ts
@@ -22,7 +22,7 @@ export function calcUnrealizedPnl({ wethAmount, buyQuote, ethPrice }: ShortPnLPa
     return new BigNumber(0)
   }
 
-  return buyQuote.minus(wethAmount).multipliedBy(ethPrice)
+  return wethAmount.minus(buyQuote).multipliedBy(ethPrice)
 }
 
 type ShortGainParams = {


### PR DESCRIPTION
# Task: fix: short PnL calc

## Description
Fixes the shortPnLCalc to be `(ETHEarnedFromSelling - ETHToPayToClosePosition) * ethPriceNow`

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
