### PR TITLE
On "full close" for shorts, stop users from partially closing their position

### DIFF
--- a/packages/frontend/src/components/Input/PrimaryInput.tsx
+++ b/packages/frontend/src/components/Input/PrimaryInput.tsx
@@ -70,6 +70,9 @@ const useStyles = makeStyles((theme) =>
     notAllowedCursor: {
       cursor: 'not-allowed',
     },
+    disabledBackground: {
+      backgroundColor: theme.palette.background.stone,
+    },
   }),
 )
 
@@ -107,7 +110,7 @@ export const PrimaryInput: React.FC<PrimaryInputType> = ({
   const classes = useStyles()
 
   return (
-    <div className={clsx(classes.container, error && classes.errorBorder)}>
+    <div className={clsx(classes.container, error && classes.errorBorder, isFullClose && classes.disabledBackground)}>
       <div className={classes.innerContainer}>
         <div className={classes.rightContainer}>
           <div className={classes.labelContainer}>

--- a/packages/frontend/src/components/Input/PrimaryInput.tsx
+++ b/packages/frontend/src/components/Input/PrimaryInput.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx'
 import React from 'react'
 
 import { LinkButton } from '../Button'
+import { Tooltips } from '@constants/enums'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -62,8 +63,12 @@ const useStyles = makeStyles((theme) =>
     inputContainer: {
       margin: theme.spacing(0.5, 0),
     },
+    fullCloseInfo: { display: 'inline-block' },
     unit: {
       fontSize: '22px',
+    },
+    notAllowedCursor: {
+      cursor: 'not-allowed',
     },
   }),
 )
@@ -80,6 +85,7 @@ type PrimaryInputType = {
   hint?: string | React.ReactNode
   error?: boolean
   isLoading?: boolean
+  isFullClose?: boolean
 }
 
 const DecimalRegex = RegExp('^[0-9]*[.]{1}[0-9]*$')
@@ -96,6 +102,7 @@ export const PrimaryInput: React.FC<PrimaryInputType> = ({
   hint,
   error = false,
   isLoading = false,
+  isFullClose = false,
 }) => {
   const classes = useStyles()
 
@@ -114,33 +121,37 @@ export const PrimaryInput: React.FC<PrimaryInputType> = ({
             ) : null}
           </div>
           <div className={classes.inputContainer}>
-            <input
-              className={classes.input}
-              value={isNaN(Number(value)) ? 0 : value}
-              onChange={(e) => {
-                let v = e.target.value
-                if (Number(v) < 0) return onChange('0')
-                if (Number(v) !== 0) {
-                  //if it is integer, remove leading zeros
-                  if (!DecimalRegex.test(v)) {
-                    v = Number(v).toString()
+            <Tooltip title={isFullClose ? Tooltips.FullcloseInput : ''} className={classes.fullCloseInfo}>
+              <input
+                className={clsx(classes.input, isFullClose && classes.notAllowedCursor)}
+                // className={classes.input}
+                value={isNaN(Number(value)) ? 0 : value}
+                disabled={isFullClose}
+                onChange={(e) => {
+                  let v = e.target.value
+                  if (Number(v) < 0) return onChange('0')
+                  if (Number(v) !== 0) {
+                    //if it is integer, remove leading zeros
+                    if (!DecimalRegex.test(v)) {
+                      v = Number(v).toString()
+                    }
+                  } else {
+                    // remain input box w single zero, but keep zero when have decimal
+                    v = v.replace(/^[0]+/g, '0')
+                    // if it is no value
+                    if (v.length === 0) {
+                      v = '0'
+                    }
                   }
-                } else {
-                  // remain input box w single zero, but keep zero when have decimal
-                  v = v.replace(/^[0]+/g, '0')
-                  // if it is no value
-                  if (v.length === 0) {
-                    v = '0'
-                  }
-                }
 
-                return onChange(v)
-              }}
-              onWheel={(e) => (e.target as any).blur()}
-              placeholder="0"
-              type="number"
-              min="0"
-            ></input>
+                  return onChange(v)
+                }}
+                onWheel={(e) => (e.target as any).blur()}
+                placeholder="0"
+                type="number"
+                min="0"
+              ></input>
+            </Tooltip>
           </div>
         </div>
         {/* <div>

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -765,6 +765,7 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
           </div>
           <div className={classes.thirdHeading}>
             <PrimaryInput
+              isFullClose={closeType === CloseType.FULL}
               value={amountInputValue}
               onChange={(v) => handleAmountInput(v)}
               label="Amount"
@@ -807,7 +808,12 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
             <Select
               label="Type of Close"
               value={closeType}
-              onChange={(event: React.ChangeEvent<{ value: unknown }>) => setCloseType(event.target.value as CloseType)}
+              onChange={(event: React.ChangeEvent<{ value: unknown }>) => {
+                if (event.target.value === CloseType.FULL) {
+                  setShortCloseMax()
+                }
+                return setCloseType(event.target.value as CloseType)
+              }}
               displayEmpty
               inputProps={{ 'aria-label': 'Without label' }}
               style={{ padding: '5px 0px', width: '100%', textAlign: 'left' }}

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -697,6 +697,7 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
   let existingLongError: string | undefined
   let priceImpactWarning: string | undefined
   let vaultIdDontLoadedError: string | undefined
+  let insufficientETHBalance: string | undefined
 
   if (connected) {
     if (finalShortAmount.lt(0) && finalShortAmount.lt(amount)) {
@@ -723,6 +724,9 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
     }
     if (isLong && !finalShortAmount.isGreaterThan(0)) {
       existingLongError = 'Close your long position to open a short'
+    }
+    if (sellCloseQuote.amountIn.gt(balance)) {
+      insufficientETHBalance = 'Insufficient ETH Balance'
     }
   }
 
@@ -773,7 +777,7 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
               actionTxt="Max"
               onActionClicked={setShortCloseMax}
               unit="oSQTH"
-              error={!!existingLongError || !!priceImpactWarning || !!closeError}
+              error={!!existingLongError || !!priceImpactWarning || !!closeError || !!insufficientETHBalance}
               isLoading={isPositionFinishedCalc}
               convertedValue={
                 !amount.isNaN()
@@ -787,6 +791,8 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
                   existingLongError
                 ) : priceImpactWarning ? (
                   priceImpactWarning
+                ) : insufficientETHBalance ? (
+                  insufficientETHBalance
                 ) : (
                   <div className={classes.hint}>
                     <span className={classes.hintTextContainer}>
@@ -864,6 +870,8 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
                 existingLongError
               ) : priceImpactWarning ? (
                 priceImpactWarning
+              ) : insufficientETHBalance ? (
+                insufficientETHBalance
               ) : (
                 <div className={classes.hint}>
                   <span>{`Balance ${balance}`}</span>
@@ -924,7 +932,8 @@ const CloseShort: React.FC<SellType> = ({ balance, open, closeTitle, setTradeCom
                   !!closeError ||
                   !!existingLongError ||
                   (shortVaults.length && shortVaults[firstValidVault].shortAmount.isZero()) ||
-                  !!vaultIdDontLoadedError
+                  !!vaultIdDontLoadedError ||
+                  !!insufficientETHBalance
                 }
                 variant={shortClosePriceImpactErrorState ? 'outlined' : 'contained'}
                 style={

--- a/packages/frontend/src/components/Trade/index.tsx
+++ b/packages/frontend/src/components/Trade/index.tsx
@@ -44,9 +44,9 @@ const Trade: React.FC<tradeType> = ({ setTradeCompleted }) => {
   const { tradeType, openPosition, setOpenPosition, setTradeType } = useTrade()
   const { positionType } = usePositions()
 
-  useEffect(() => {
-    setTradeType(positionType === PositionType.SHORT ? 1 : 0)
-  }, [positionType])
+  // useEffect(() => {
+  //   setTradeType(positionType === PositionType.SHORT ? 1 : 0)
+  // }, [positionType])
 
   return (
     <div>

--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -70,6 +70,7 @@ export enum Tooltips {
   StrategyCollRatio = 'The collateralization ratio for the whole strategy',
   StrategyEarnFunding = 'You earn funding by depositing into the strategy',
   StrategyProfitThreshold = 'Based on current funding, crab strategy would be unprofitable if ETH moves more than approximately the profit threshold in either direction each day.',
+  FullcloseInput = 'Select partial close to edit input',
 }
 
 export enum Links {

--- a/packages/frontend/src/hooks/usePositions.ts
+++ b/packages/frontend/src/hooks/usePositions.ts
@@ -216,14 +216,7 @@ export const useLPPositions = () => {
         }
       }) || []
     )
-  }, [
-    data?.positions,
-    pool,
-    ethPrice.toString(),
-    squeethInitialPrice.toString(),
-    ethPrice.toString(),
-    data?.positions?.length,
-  ])
+  }, [pool, ethPrice.toString(), squeethInitialPrice.toString(), ethPrice.toString(), data?.positions?.length])
 
   useEffect(() => {
     if (positionAndFees && !gphLoading) {


### PR DESCRIPTION
# Task: On "full close" for shorts, stop users from partially closing their position

## Description

- Disables input when on full close
- Adds tooltip to inform the user to select partial close to partially close.

Fixes # (issue)
#63 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
