### PR TITLE
fix: interface thought crab positions were short on trade page

### DIFF
--- a/packages/frontend/src/context/positions.tsx
+++ b/packages/frontend/src/context/positions.tsx
@@ -159,7 +159,11 @@ const PositionsProvider: React.FC = ({ children }) => {
     firstValidVault,
     vaultId,
     isLong: positionType === PositionType.LONG,
-    isShort: positionType === PositionType.SHORT,
+    isShort:
+      positionType === PositionType.SHORT &&
+      shortDebt.isGreaterThan(0) &&
+      shortVaults.length &&
+      shortVaults[firstValidVault]?.collateralAmount?.isGreaterThan(0),
     isLP: squeethLiquidity.gt(0) || wethLiquidity.gt(0),
     longRealizedPNL,
     shortRealizedPNL,


### PR DESCRIPTION
# Task: fix: interface thought crab positions were short on trade page

## Description
Interface was classifying crab positions as short on the trade page. Adds logic to distinguish between short and crab on the trade page position card and in the position context for classifying positions as short 

Fixes # (issue)
#166 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
