### PR TITLE
feat: flash close short and buy long

### DIFF
--- a/packages/hardhat/contracts/interfaces/IController.sol
+++ b/packages/hardhat/contracts/interfaces/IController.sol
@@ -55,7 +55,7 @@ interface IController {
         uint256 _withdrawAmount
     ) external;
 
-    function burnOnPowerPerpAmount(
+    function burnPowerPerpAmount(
         uint256 _vaultId,
         uint256 _powerPerpAmount,
         uint256 _withdrawAmount

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -42,6 +42,7 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 flashSwappedCollateral;
         uint256 totalCollateralToDeposit;
         uint256 wPowerPerpAmount;
+
     }
 
     event FlashswapWMint(

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -27,11 +27,6 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
     /// @dev enum to differentiate between uniswap swap callback function source
     enum FLASH_SOURCE {
-        FLASH_W_MINT
-    }
-
-    /// @dev enum to differentiate between uniswap swap callback function source
-    enum FLASH_SOURCE {
         FLASH_W_MINT,
         FLASH_W_BURN
     }
@@ -48,6 +43,12 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 flashSwappedCollateral;
         uint256 totalCollateralToDeposit;
         uint256 wPowerPerpAmount;
+    }
+
+    struct FlashWBurnData {
+        uint256 vaultId;
+        uint256 wPowerPerpAmount;
+        uint256 collateralToWithdraw;
     }
 
     event FlashswapWMint(

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -130,6 +130,9 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         if (FLASH_SOURCE(_callSource) == FLASH_SOURCE.FLASH_W_MINT) {
             flashswapWMintData memory data = abi.decode(_callData, (flashswapWMintData));
 
+            console.log("data.flashSwapedCollateral", data.flashSwapedCollateral);
+            console.log("balance this", IWETH9(weth).balanceOf(address(this)));
+
             // convert WETH to ETH as Uniswap uses WETH
             IWETH9(weth).withdraw(IWETH9(weth).balanceOf(address(this)));
 

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -161,12 +161,7 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
             _wPowerPerpAmountToBurn.add(_wPowerPerpAmountToBuy),
             _maxToPay,
             uint8(FLASH_SOURCE.FLASH_W_BURN),
-            abi.encodePacked(
-                _vaultId,
-                _wPowerPerpAmountToBurn,
-                _wPowerPerpAmountToBuy,
-                _collateralToWithdraw
-            )
+            abi.encodePacked(_vaultId, _wPowerPerpAmountToBurn, _wPowerPerpAmountToBuy, _collateralToWithdraw)
         );
 
         emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmountToBurn, _collateralToWithdraw, _wPowerPerpAmountToBuy);

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -30,6 +30,11 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         FLASH_W_MINT
     }
 
+    /// @dev enum to differentiate between uniswap swap callback function source
+    enum FLASH_SOURCE {
+        FLASH_W_MINT
+    }
+
     address public immutable controller;
     address public immutable oracle;
     address public immutable shortPowerPerp;

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -69,6 +69,8 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 wPowerPerpAmountToBuy
     );
 
+    event FlashWBurn(address indexed withdrawer, uint256 vaultId, uint256 wPowerPerpAmount, uint256 collateralAmount, uint256 wPowerPerpBought);    
+
     constructor(
         address _controller,
         address _oracle,

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -46,11 +46,12 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 totalCollateralToDeposit;
         uint256 wPowerPerpAmount;
     }
-
     struct FlashWBurnData {
         uint256 vaultId;
-        uint256 wPowerPerpAmount;
+        uint256 wPowerPerpAmountToBurn;
+        uint256 wPowerPerpAmountToBuy;
         uint256 collateralToWithdraw;
+        uint256 collateralToBuyWith;
     }
 
     event FlashswapWMint(
@@ -60,8 +61,13 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 swappedCollateralAmount,
         uint256 collateralAmount
     );
-
-    event FlashWBurn(address indexed withdrawer, uint256 vaultId, uint256 wPowerPerpAmount, uint256 collateralAmount, uint256 wPowerPerpBought);    
+    event FlashWBurn(
+        address indexed withdrawer,
+        uint256 vaultId,
+        uint256 wPowerPerpAmountToBurn,
+        uint256 collateralAmountToWithdraw,
+        uint256 wPowerPerpAmountToBuy
+    );
 
     constructor(
         address _controller,
@@ -133,42 +139,33 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
     /**
      * @notice flash close position and buy long squeeth
+     * @dev this function 
      * @param _vaultId vault ID
-     * @param _wPowerPerpAmount amount of WPowerPerp to burn
-     * @param _collateralToWithdraw amount of collateral to withdraw
-     * @param _minToReceive minimum amount of long WPowerPerp to receive
+     * @param _wPowerPerpAmountToBurn amount of WPowerPerp to burn
+     * @param _wPowerPerpAmountToBuy amount of WPowerPerp to buy
+     * @param _collateralToWithdraw amount of collateral to withdraw from vault
+     * @param _collateralToBuyWith amount of collateral from vault to use to buy long
      */
-    function flashWBurnBuyLong(
+    function flashswapWBurnBuyLong(
         uint256 _vaultId,
-        uint256 _wPowerPerpAmount,
+        uint256 _wPowerPerpAmountToBurn,
+        uint256 _wPowerPerpAmountToBuy,
         uint256 _collateralToWithdraw,
-        uint256 _minToReceive
-    ) external {
+        uint256 _collateralToBuyWith
+    ) external payable {
+        require(_collateralToBuyWith <= _collateralToWithdraw.add(msg.value), "Not enough collateral");
+
         _exactOutFlashSwap(
             weth,
             wPowerPerp,
             IUniswapV3Pool(wPowerPerpPool).fee(),
-            _wPowerPerpAmount,
-            _collateralToWithdraw,
+            _wPowerPerpAmountToBurn.add(_wPowerPerpAmountToBuy),
+            _collateralToBuyWith.add(msg.value),
             uint8(FLASH_SOURCE.FLASH_W_BURN),
-            abi.encodePacked(_vaultId, _wPowerPerpAmount, _collateralToWithdraw)
+            abi.encodePacked(_vaultId, _wPowerPerpAmountToBurn, _wPowerPerpAmountToBuy, _collateralToWithdraw, _collateralToBuyWith.add(msg.value))
         );
 
-        ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
-            tokenIn: weth,
-            tokenOut: wPowerPerp,
-            fee: IUniswapV3Pool(wPowerPerpPool).fee(),
-            recipient: msg.sender,
-            deadline: block.timestamp,
-            amountIn: IWETH9(weth).balanceOf(address(this)),
-            amountOutMinimum: _minToReceive,
-            sqrtPriceLimitX96: 0
-        });
-
-        uint256 amountOut = ISwapRouter(swapRouter).exactInputSingle(swapParams);
-        IWPowerPerp(wPowerPerp).transfer(msg.sender, IWPowerPerp(wPowerPerp).balanceOf(address(this)));
-
-        emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmount, _collateralToWithdraw, amountOut);
+        emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmountToBurn, _collateralToWithdraw, _wPowerPerpAmountToBuy);
     }
 
     /**
@@ -216,12 +213,16 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
             IController(controller).burnWPowerPerpAmount(
                 data.vaultId,
-                data.wPowerPerpAmount,
+                data.wPowerPerpAmountToBurn,
                 data.collateralToWithdraw
             );
-
-            IWETH9(weth).deposit{value: data.collateralToWithdraw}();
+            IWETH9(weth).deposit{value: _amountToPay}();
             IWETH9(weth).transfer(wPowerPerpPool, _amountToPay);
+            IWPowerPerp(wPowerPerp).transfer(_caller, data.wPowerPerpAmountToBuy);
+
+            if (address(this).balance > 0) {
+                payable(_caller).sendValue(address(this).balance);
+            }
         }
     }
 }

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -116,7 +116,11 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         emit FlashswapWMint(msg.sender, _vaultId, _wPowerPerpAmount, amountToFlashswap, _collateralAmount);
     }
 
-    function flashWBurn(uint256 _vaultId, uint256 _wPowerPerpAmount, uint256 _collateralToWithdraw) external {
+    function flashWBurn(
+        uint256 _vaultId,
+        uint256 _wPowerPerpAmount,
+        uint256 _collateralToWithdraw
+    ) external {
         _exactOutFlashSwap(
             weth,
             wPowerPerp,
@@ -126,7 +130,6 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
             uint8(FLASH_SOURCE.FLASH_W_BURN),
             abi.encodePacked(_vaultId, _wPowerPerpAmount, _collateralToWithdraw)
         );
-
     }
 
     /**
@@ -169,11 +172,14 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
             // this is a newly open vault, transfer to the user
             if (data.vaultId == 0) IShortPowerPerp(shortPowerPerp).safeTransferFrom(address(this), _caller, vaultId);
-        }
-        else if (FLASH_SOURCE(_callSource) == FLASH_SOURCE.FLASH_W_BURN) {
+        } else if (FLASH_SOURCE(_callSource) == FLASH_SOURCE.FLASH_W_BURN) {
             FlashWBurnData memory data = abi.decode(_callData, (FlashWBurnData));
 
-            IController(controller).burnWPowerPerpAmount(data.vaultId, data.wPowerPerpAmount, data.collateralToWithdraw);
+            IController(controller).burnWPowerPerpAmount(
+                data.vaultId,
+                data.wPowerPerpAmount,
+                data.collateralToWithdraw
+            );
 
             IWETH9(weth).deposit{value: _amountToPay}();
             IWETH9(weth).transfer(wPowerPerpPool, _amountToPay);

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -139,7 +139,7 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
     /**
      * @notice flash close position and buy long squeeth
-     * @dev this function 
+     * @dev this function
      * @param _vaultId vault ID
      * @param _wPowerPerpAmountToBurn amount of WPowerPerp to burn
      * @param _wPowerPerpAmountToBuy amount of WPowerPerp to buy
@@ -162,7 +162,13 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
             _wPowerPerpAmountToBurn.add(_wPowerPerpAmountToBuy),
             _collateralToBuyWith.add(msg.value),
             uint8(FLASH_SOURCE.FLASH_W_BURN),
-            abi.encodePacked(_vaultId, _wPowerPerpAmountToBurn, _wPowerPerpAmountToBuy, _collateralToWithdraw, _collateralToBuyWith.add(msg.value))
+            abi.encodePacked(
+                _vaultId,
+                _wPowerPerpAmountToBurn,
+                _wPowerPerpAmountToBuy,
+                _collateralToWithdraw,
+                _collateralToBuyWith.add(msg.value)
+            )
         );
 
         emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmountToBurn, _collateralToWithdraw, _wPowerPerpAmountToBuy);

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -49,8 +49,10 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
     struct FlashWBurnData {
         uint256 vaultId;
-        uint256 wPowerPerpAmount;
+        uint256 wPowerPerpAmountToBurn;
+        uint256 wPowerPerpAmountToBuy;
         uint256 collateralToWithdraw;
+        uint256 collateralToBuyWith;
     }
 
     event FlashswapWMint(
@@ -64,9 +66,9 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
     event FlashWBurn(
         address indexed withdrawer,
         uint256 vaultId,
-        uint256 wPowerPerpAmount,
-        uint256 collateralAmount,
-        uint256 wPowerPerpBought
+        uint256 wPowerPerpAmountToBurn,
+        uint256 collateralAmountToWithdraw,
+        uint256 wPowerPerpAmountToBuy
     );
 
     constructor(
@@ -133,42 +135,47 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
     /**
      * @notice flash close position and buy long squeeth
+     * @dev this function 
      * @param _vaultId vault ID
-     * @param _wPowerPerpAmount amount of WPowerPerp to burn
-     * @param _collateralToWithdraw amount of collateral to withdraw
-     * @param _minToReceive minimum amount of long WPowerPerp to receive
+     * @param _wPowerPerpAmountToBurn amount of WPowerPerp to burn
+     * @param _wPowerPerpAmountToBuy amount of WPowerPerp to buy
+     * @param _collateralToWithdraw amount of collateral to withdraw from vault
+     * @param _collateralToBuyWith amount of collateral from vault to use to buy long
      */
-    function flashWBurnBuyLong(
+    function flashswapWBurnBuyLong(
         uint256 _vaultId,
-        uint256 _wPowerPerpAmount,
+        uint256 _wPowerPerpAmountToBurn,
+        uint256 _wPowerPerpAmountToBuy,
         uint256 _collateralToWithdraw,
-        uint256 _minToReceive
-    ) external {
+        uint256 _collateralToBuyWith
+    ) external payable {
+        require(_collateralToBuyWith <= _collateralToWithdraw.add(msg.value), "Not enough collateral");
+
         _exactOutFlashSwap(
             weth,
             wPowerPerp,
             IUniswapV3Pool(wPowerPerpPool).fee(),
-            _wPowerPerpAmount,
-            _collateralToWithdraw,
+            _wPowerPerpAmountToBurn.add(_wPowerPerpAmountToBuy),
+            _collateralToBuyWith.add(msg.value),
             uint8(FLASH_SOURCE.FLASH_W_BURN),
-            abi.encodePacked(_vaultId, _wPowerPerpAmount, _collateralToWithdraw)
+            abi.encodePacked(_vaultId, _wPowerPerpAmountToBurn, _wPowerPerpAmountToBuy, _collateralToWithdraw, _collateralToBuyWith.add(msg.value))
         );
 
-        ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
-            tokenIn: weth,
-            tokenOut: wPowerPerp,
-            fee: IUniswapV3Pool(wPowerPerpPool).fee(),
-            recipient: msg.sender,
-            deadline: block.timestamp,
-            amountIn: IWETH9(weth).balanceOf(address(this)),
-            amountOutMinimum: _minToReceive,
-            sqrtPriceLimitX96: 0
-        });
+        // ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
+        //     tokenIn: weth,
+        //     tokenOut: wPowerPerp,
+        //     fee: IUniswapV3Pool(wPowerPerpPool).fee(),
+        //     recipient: msg.sender,
+        //     deadline: block.timestamp,
+        //     amountIn: IWETH9(weth).balanceOf(address(this)),
+        //     amountOutMinimum: _minToReceive,
+        //     sqrtPriceLimitX96: 0
+        // });
 
-        uint256 amountOut = ISwapRouter(swapRouter).exactInputSingle(swapParams);
-        IWPowerPerp(wPowerPerp).transfer(msg.sender, IWPowerPerp(wPowerPerp).balanceOf(address(this)));
+        // uint256 amountOut = ISwapRouter(swapRouter).exactInputSingle(swapParams);
+        // IWPowerPerp(wPowerPerp).transfer(msg.sender, IWPowerPerp(wPowerPerp).balanceOf(address(this)));
 
-        emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmount, _collateralToWithdraw, amountOut);
+        emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmountToBurn, _collateralToWithdraw, _wPowerPerpAmountToBuy);
     }
 
     /**
@@ -212,16 +219,30 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
             // this is a newly open vault, transfer to the user
             if (data.vaultId == 0) IShortPowerPerp(shortPowerPerp).safeTransferFrom(address(this), _caller, vaultId);
         } else if (FLASH_SOURCE(_callSource) == FLASH_SOURCE.FLASH_W_BURN) {
+    //             struct FlashWBurnData {
+    //     uint256 vaultId;
+    //     uint256 wPowerPerpAmountToBurn;
+    //     uint256 wPowerPerpAmountToBuy;
+    //     uint256 collateralToWithdraw;
+    //     uint256 collateralToBuyWith;
+    // }
+
             FlashWBurnData memory data = abi.decode(_callData, (FlashWBurnData));
 
             IController(controller).burnWPowerPerpAmount(
                 data.vaultId,
-                data.wPowerPerpAmount,
+                data.wPowerPerpAmountToBurn,
                 data.collateralToWithdraw
             );
 
-            IWETH9(weth).deposit{value: data.collateralToWithdraw}();
+            IWETH9(weth).deposit{value: _amountToPay}();
             IWETH9(weth).transfer(wPowerPerpPool, _amountToPay);
+
+            IWPowerPerp(wPowerPerp).transfer(_caller, data.wPowerPerpAmountToBuy);
+
+            if (address(this).balance > 0) {
+                payable(_caller).sendValue(address(this).balance);
+            }
         }
     }
 }

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -61,7 +61,13 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 collateralAmount
     );
 
-    event FlashWBurn(address indexed withdrawer, uint256 vaultId, uint256 wPowerPerpAmount, uint256 collateralAmount, uint256 wPowerPerpBought);    
+    event FlashWBurn(
+        address indexed withdrawer,
+        uint256 vaultId,
+        uint256 wPowerPerpAmount,
+        uint256 collateralAmount,
+        uint256 wPowerPerpBought
+    );
 
     constructor(
         address _controller,

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -42,7 +42,6 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 flashSwappedCollateral;
         uint256 totalCollateralToDeposit;
         uint256 wPowerPerpAmount;
-
     }
 
     event FlashswapWMint(

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -69,8 +69,6 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 wPowerPerpAmountToBuy
     );
 
-    event FlashWBurn(address indexed withdrawer, uint256 vaultId, uint256 wPowerPerpAmount, uint256 collateralAmount, uint256 wPowerPerpBought);    
-
     constructor(
         address _controller,
         address _oracle,

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -130,9 +130,6 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         if (FLASH_SOURCE(_callSource) == FLASH_SOURCE.FLASH_W_MINT) {
             flashswapWMintData memory data = abi.decode(_callData, (flashswapWMintData));
 
-            console.log("data.flashSwapedCollateral", data.flashSwapedCollateral);
-            console.log("balance this", IWETH9(weth).balanceOf(address(this)));
-
             // convert WETH to ETH as Uniswap uses WETH
             IWETH9(weth).withdraw(IWETH9(weth).balanceOf(address(this)));
 

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -51,7 +51,6 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 wPowerPerpAmountToBurn;
         uint256 wPowerPerpAmountToBuy;
         uint256 collateralToWithdraw;
-        uint256 collateralToBuyWith;
     }
 
     event FlashswapWMint(
@@ -144,30 +143,29 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
      * @param _wPowerPerpAmountToBurn amount of WPowerPerp to burn
      * @param _wPowerPerpAmountToBuy amount of WPowerPerp to buy
      * @param _collateralToWithdraw amount of collateral to withdraw from vault
-     * @param _collateralToBuyWith amount of collateral from vault to use to buy long
+     * @param _maxToPay max amount of collateral to pay for WPowerPerp token
      */
     function flashswapWBurnBuyLong(
         uint256 _vaultId,
         uint256 _wPowerPerpAmountToBurn,
         uint256 _wPowerPerpAmountToBuy,
         uint256 _collateralToWithdraw,
-        uint256 _collateralToBuyWith
+        uint256 _maxToPay
     ) external payable {
-        require(_collateralToBuyWith <= _collateralToWithdraw.add(msg.value), "Not enough collateral");
+        require(_maxToPay <= _collateralToWithdraw.add(msg.value), "Not enough collateral");
 
         _exactOutFlashSwap(
             weth,
             wPowerPerp,
             IUniswapV3Pool(wPowerPerpPool).fee(),
             _wPowerPerpAmountToBurn.add(_wPowerPerpAmountToBuy),
-            _collateralToBuyWith.add(msg.value),
+            _maxToPay,
             uint8(FLASH_SOURCE.FLASH_W_BURN),
             abi.encodePacked(
                 _vaultId,
                 _wPowerPerpAmountToBurn,
                 _wPowerPerpAmountToBuy,
-                _collateralToWithdraw,
-                _collateralToBuyWith.add(msg.value)
+                _collateralToWithdraw
             )
         );
 

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -174,7 +174,7 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
             IController(controller).burnWPowerPerpAmount(data.vaultId, data.wPowerPerpAmount, data.collateralToWithdraw);
 
-            IWETH9.deposit(_amountToPay);
+            IWETH9(weth).deposit{value: _amountToPay}();
             IWETH9(weth).transfer(wPowerPerpPool, _amountToPay);
 
             /// TODO: buy long or send ETH back

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -49,10 +49,8 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
     struct FlashWBurnData {
         uint256 vaultId;
-        uint256 wPowerPerpAmountToBurn;
-        uint256 wPowerPerpAmountToBuy;
+        uint256 wPowerPerpAmount;
         uint256 collateralToWithdraw;
-        uint256 collateralToBuyWith;
     }
 
     event FlashswapWMint(
@@ -63,13 +61,7 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         uint256 collateralAmount
     );
 
-    event FlashWBurn(
-        address indexed withdrawer,
-        uint256 vaultId,
-        uint256 wPowerPerpAmountToBurn,
-        uint256 collateralAmountToWithdraw,
-        uint256 wPowerPerpAmountToBuy
-    );
+    event FlashWBurn(address indexed withdrawer, uint256 vaultId, uint256 wPowerPerpAmount, uint256 collateralAmount, uint256 wPowerPerpBought);    
 
     constructor(
         address _controller,
@@ -113,6 +105,12 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
         require(msg.sender == weth || msg.sender == address(controller), "Cannot receive eth");
     }
 
+    /**
+     * @notice flash mint WPowerPerp using flashswap
+     * @param _vaultId vault ID
+     * @param _wPowerPerpAmount amount of WPowerPerp to mint
+     * @param _collateralAmount total collateral amount to deposit
+     */
     function flashswapWMint(
         uint256 _vaultId,
         uint256 _wPowerPerpAmount,
@@ -135,47 +133,42 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
 
     /**
      * @notice flash close position and buy long squeeth
-     * @dev this function 
      * @param _vaultId vault ID
-     * @param _wPowerPerpAmountToBurn amount of WPowerPerp to burn
-     * @param _wPowerPerpAmountToBuy amount of WPowerPerp to buy
-     * @param _collateralToWithdraw amount of collateral to withdraw from vault
-     * @param _collateralToBuyWith amount of collateral from vault to use to buy long
+     * @param _wPowerPerpAmount amount of WPowerPerp to burn
+     * @param _collateralToWithdraw amount of collateral to withdraw
+     * @param _minToReceive minimum amount of long WPowerPerp to receive
      */
-    function flashswapWBurnBuyLong(
+    function flashWBurnBuyLong(
         uint256 _vaultId,
-        uint256 _wPowerPerpAmountToBurn,
-        uint256 _wPowerPerpAmountToBuy,
+        uint256 _wPowerPerpAmount,
         uint256 _collateralToWithdraw,
-        uint256 _collateralToBuyWith
-    ) external payable {
-        require(_collateralToBuyWith <= _collateralToWithdraw.add(msg.value), "Not enough collateral");
-
+        uint256 _minToReceive
+    ) external {
         _exactOutFlashSwap(
             weth,
             wPowerPerp,
             IUniswapV3Pool(wPowerPerpPool).fee(),
-            _wPowerPerpAmountToBurn.add(_wPowerPerpAmountToBuy),
-            _collateralToBuyWith.add(msg.value),
+            _wPowerPerpAmount,
+            _collateralToWithdraw,
             uint8(FLASH_SOURCE.FLASH_W_BURN),
-            abi.encodePacked(_vaultId, _wPowerPerpAmountToBurn, _wPowerPerpAmountToBuy, _collateralToWithdraw, _collateralToBuyWith.add(msg.value))
+            abi.encodePacked(_vaultId, _wPowerPerpAmount, _collateralToWithdraw)
         );
 
-        // ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
-        //     tokenIn: weth,
-        //     tokenOut: wPowerPerp,
-        //     fee: IUniswapV3Pool(wPowerPerpPool).fee(),
-        //     recipient: msg.sender,
-        //     deadline: block.timestamp,
-        //     amountIn: IWETH9(weth).balanceOf(address(this)),
-        //     amountOutMinimum: _minToReceive,
-        //     sqrtPriceLimitX96: 0
-        // });
+        ISwapRouter.ExactInputSingleParams memory swapParams = ISwapRouter.ExactInputSingleParams({
+            tokenIn: weth,
+            tokenOut: wPowerPerp,
+            fee: IUniswapV3Pool(wPowerPerpPool).fee(),
+            recipient: msg.sender,
+            deadline: block.timestamp,
+            amountIn: IWETH9(weth).balanceOf(address(this)),
+            amountOutMinimum: _minToReceive,
+            sqrtPriceLimitX96: 0
+        });
 
-        // uint256 amountOut = ISwapRouter(swapRouter).exactInputSingle(swapParams);
-        // IWPowerPerp(wPowerPerp).transfer(msg.sender, IWPowerPerp(wPowerPerp).balanceOf(address(this)));
+        uint256 amountOut = ISwapRouter(swapRouter).exactInputSingle(swapParams);
+        IWPowerPerp(wPowerPerp).transfer(msg.sender, IWPowerPerp(wPowerPerp).balanceOf(address(this)));
 
-        emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmountToBurn, _collateralToWithdraw, _wPowerPerpAmountToBuy);
+        emit FlashWBurn(msg.sender, _vaultId, _wPowerPerpAmount, _collateralToWithdraw, amountOut);
     }
 
     /**
@@ -219,30 +212,16 @@ contract ControllerHelper is FlashControllerHelper, IERC721Receiver {
             // this is a newly open vault, transfer to the user
             if (data.vaultId == 0) IShortPowerPerp(shortPowerPerp).safeTransferFrom(address(this), _caller, vaultId);
         } else if (FLASH_SOURCE(_callSource) == FLASH_SOURCE.FLASH_W_BURN) {
-    //             struct FlashWBurnData {
-    //     uint256 vaultId;
-    //     uint256 wPowerPerpAmountToBurn;
-    //     uint256 wPowerPerpAmountToBuy;
-    //     uint256 collateralToWithdraw;
-    //     uint256 collateralToBuyWith;
-    // }
-
             FlashWBurnData memory data = abi.decode(_callData, (FlashWBurnData));
 
             IController(controller).burnWPowerPerpAmount(
                 data.vaultId,
-                data.wPowerPerpAmountToBurn,
+                data.wPowerPerpAmount,
                 data.collateralToWithdraw
             );
 
-            IWETH9(weth).deposit{value: _amountToPay}();
+            IWETH9(weth).deposit{value: data.collateralToWithdraw}();
             IWETH9(weth).transfer(wPowerPerpPool, _amountToPay);
-
-            IWPowerPerp(wPowerPerp).transfer(_caller, data.wPowerPerpAmountToBuy);
-
-            if (address(this).balance > 0) {
-                payable(_caller).sendValue(address(this).balance);
-            }
         }
     }
 }

--- a/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
@@ -66,7 +66,7 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
                 :  uint256(amount1Delta);
         
         //calls the strategy function that uses the proceeds from flash swap and executes logic to have an amount of token to repay the flash swap
-        _flashCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
+        _swapCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
     }
 
     /**

--- a/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
@@ -60,10 +60,13 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
         CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
 
         //determine the amount that needs to be repaid as part of the flashswap
-        uint256 amountToPay = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
-
+        uint256 amountToPay =
+            amount0Delta > 0
+                ?  uint256(amount0Delta)
+                :  uint256(amount1Delta);
+        
         //calls the strategy function that uses the proceeds from flash swap and executes logic to have an amount of token to repay the flash swap
-        _swapCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
+        _flashCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
     }
 
     /**

--- a/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
@@ -68,7 +68,7 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
                 :  uint256(amount1Delta);
         
         //calls the strategy function that uses the proceeds from flash swap and executes logic to have an amount of token to repay the flash swap
-        _flashCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
+        _swapCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
     }
 
     /**
@@ -154,6 +154,7 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * param _callData arbitrary data assigned with the flashswap call
      * param _callSource function call source
      */
+<<<<<<< HEAD
     function _swapCallback(
         address, /*_caller*/
         address, /*_tokenIn*/
@@ -171,6 +172,17 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * @param _sqrtPriceLimitX96 price limit
      * @return amount of token bought (amountOut)
      */
+=======
+    function _swapCallback(address /*_caller*/, address /*_tokenIn*/, address /*_tokenOut*/, uint24 /*_fee*/, uint256 /*_amountToPay*/, bytes memory _callData, uint8 _callSource) internal virtual {}
+    
+    /** 
+    * @notice internal function for exact-in swap on uniswap (specify exact amount to pay)
+    * @param _amountIn amount of token to pay
+    * @param _recipient recipient for receive
+    * @param _sqrtPriceLimitX96 price limit
+    * @return amount of token bought (amountOut)
+    */
+>>>>>>> dd4a6c0 (fix: compilation)
     function _exactInputInternal(
         uint256 _amountIn,
         address _recipient,

--- a/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
@@ -8,12 +8,12 @@ import "@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.so
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
 // lib
-import "@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol";
-import "@uniswap/v3-periphery/contracts/libraries/Path.sol";
-import "@uniswap/v3-periphery/contracts/libraries/PoolAddress.sol";
-import "@uniswap/v3-periphery/contracts/libraries/CallbackValidation.sol";
-import "@uniswap/v3-core/contracts/libraries/TickMath.sol";
-import "@uniswap/v3-core/contracts/libraries/SafeCast.sol";
+import '@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol';
+import '@uniswap/v3-periphery/contracts/libraries/Path.sol';
+import '@uniswap/v3-periphery/contracts/libraries/PoolAddress.sol';
+import '@uniswap/v3-periphery/contracts/libraries/CallbackValidation.sol';
+import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
+import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';
 
 contract FlashControllerHelper is IUniswapV3SwapCallback {
     using Path for bytes;
@@ -35,7 +35,9 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * @dev constructor
      * @param _factory uniswap factory address
      */
-    constructor(address _factory) {
+    constructor(
+        address _factory
+    ) {
         require(_factory != address(0), "invalid factory address");
         factory = _factory;
     }
@@ -60,10 +62,13 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
         CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
 
         //determine the amount that needs to be repaid as part of the flashswap
-        uint256 amountToPay = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
-
+        uint256 amountToPay =
+            amount0Delta > 0
+                ?  uint256(amount0Delta)
+                :  uint256(amount1Delta);
+        
         //calls the strategy function that uses the proceeds from flash swap and executes logic to have an amount of token to repay the flash swap
-        _swapCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
+        _flashCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
     }
 
     /**

--- a/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
@@ -149,10 +149,6 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * param _callData arbitrary data assigned with the flashswap call
      * param _callSource function call source
      */
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 693872a (fix: lint)
     function _swapCallback(
         address, /*_caller*/
         address, /*_tokenIn*/
@@ -170,20 +166,6 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * @param _sqrtPriceLimitX96 price limit
      * @return amount of token bought (amountOut)
      */
-<<<<<<< HEAD
-=======
-    function _swapCallback(address /*_caller*/, address /*_tokenIn*/, address /*_tokenOut*/, uint24 /*_fee*/, uint256 /*_amountToPay*/, bytes memory _callData, uint8 _callSource) internal virtual {}
-    
-    /** 
-    * @notice internal function for exact-in swap on uniswap (specify exact amount to pay)
-    * @param _amountIn amount of token to pay
-    * @param _recipient recipient for receive
-    * @param _sqrtPriceLimitX96 price limit
-    * @return amount of token bought (amountOut)
-    */
->>>>>>> dd4a6c0 (fix: compilation)
-=======
->>>>>>> 693872a (fix: lint)
     function _exactInputInternal(
         uint256 _amountIn,
         address _recipient,
@@ -191,10 +173,6 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
         SwapCallbackData memory data
     ) private returns (uint256) {
         (address tokenIn, address tokenOut, uint24 fee) = data.path.decodeFirstPool();
-<<<<<<< HEAD
-=======
-
->>>>>>> 693872a (fix: lint)
         //uniswap token0 has a lower address than token1
         //if tokenIn<tokenOut, we are selling an exact amount of token0 in exchange for token1
         //zeroForOne determines which token is being sold and which is being bought

--- a/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
@@ -8,12 +8,12 @@ import "@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.so
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
 // lib
-import '@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol';
-import '@uniswap/v3-periphery/contracts/libraries/Path.sol';
-import '@uniswap/v3-periphery/contracts/libraries/PoolAddress.sol';
-import '@uniswap/v3-periphery/contracts/libraries/CallbackValidation.sol';
-import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
-import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';
+import "@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol";
+import "@uniswap/v3-periphery/contracts/libraries/Path.sol";
+import "@uniswap/v3-periphery/contracts/libraries/PoolAddress.sol";
+import "@uniswap/v3-periphery/contracts/libraries/CallbackValidation.sol";
+import "@uniswap/v3-core/contracts/libraries/TickMath.sol";
+import "@uniswap/v3-core/contracts/libraries/SafeCast.sol";
 
 contract FlashControllerHelper is IUniswapV3SwapCallback {
     using Path for bytes;
@@ -35,9 +35,7 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * @dev constructor
      * @param _factory uniswap factory address
      */
-    constructor(
-        address _factory
-    ) {
+    constructor(address _factory) {
         require(_factory != address(0), "invalid factory address");
         factory = _factory;
     }
@@ -62,11 +60,8 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
         CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
 
         //determine the amount that needs to be repaid as part of the flashswap
-        uint256 amountToPay =
-            amount0Delta > 0
-                ?  uint256(amount0Delta)
-                :  uint256(amount1Delta);
-        
+        uint256 amountToPay = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
+
         //calls the strategy function that uses the proceeds from flash swap and executes logic to have an amount of token to repay the flash swap
         _swapCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
     }
@@ -155,6 +150,9 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * param _callSource function call source
      */
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 693872a (fix: lint)
     function _swapCallback(
         address, /*_caller*/
         address, /*_tokenIn*/
@@ -172,6 +170,7 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
      * @param _sqrtPriceLimitX96 price limit
      * @return amount of token bought (amountOut)
      */
+<<<<<<< HEAD
 =======
     function _swapCallback(address /*_caller*/, address /*_tokenIn*/, address /*_tokenOut*/, uint24 /*_fee*/, uint256 /*_amountToPay*/, bytes memory _callData, uint8 _callSource) internal virtual {}
     
@@ -183,6 +182,8 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
     * @return amount of token bought (amountOut)
     */
 >>>>>>> dd4a6c0 (fix: compilation)
+=======
+>>>>>>> 693872a (fix: lint)
     function _exactInputInternal(
         uint256 _amountIn,
         address _recipient,
@@ -190,6 +191,10 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
         SwapCallbackData memory data
     ) private returns (uint256) {
         (address tokenIn, address tokenOut, uint24 fee) = data.path.decodeFirstPool();
+<<<<<<< HEAD
+=======
+
+>>>>>>> 693872a (fix: lint)
         //uniswap token0 has a lower address than token1
         //if tokenIn<tokenOut, we are selling an exact amount of token0 in exchange for token1
         //zeroForOne determines which token is being sold and which is being bought

--- a/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/FlashControllerHelper.sol
@@ -60,11 +60,8 @@ contract FlashControllerHelper is IUniswapV3SwapCallback {
         CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
 
         //determine the amount that needs to be repaid as part of the flashswap
-        uint256 amountToPay =
-            amount0Delta > 0
-                ?  uint256(amount0Delta)
-                :  uint256(amount1Delta);
-        
+        uint256 amountToPay = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
+
         //calls the strategy function that uses the proceeds from flash swap and executes logic to have an amount of token to repay the flash swap
         _swapCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
     }

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -73,7 +73,7 @@ describe("Controller helper integration test", function () {
     await controller.connect(owner).setFeeRate(0)
     
     const ControllerHelperContract = await ethers.getContractFactory("ControllerHelper");
-    controllerHelper = (await ControllerHelperContract.deploy(controller.address, oracle.address, shortSqueeth.address, wSqueethPool.address, wSqueeth.address, weth.address, uniswapRouter.address, uniswapFactory.address)) as ControllerHelper;
+    controllerHelper = (await ControllerHelperContract.deploy(controller.address, oracle.address, shortSqueeth.address, wSqueethPool.address, wSqueeth.address, weth.address, swapRouter.address, uniswapFactory.address)) as ControllerHelper;
   })
 
   this.beforeAll("Seed pool liquidity", async() => {

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -154,15 +154,21 @@ describe("Controller helper integration test", function () {
 
       const vaultBefore = await controller.vaults(vaultId)
       const longBalanceBefore = await wSqueeth.balanceOf(depositor.address)
+      const squeethPrice = await oracle.getTwap(wSqueethPool.address, wSqueeth.address, weth.address, 420, true)
+      const squeethToBuy = vaultBefore.collateralAmount.div(squeethPrice)
 
-      await controllerHelper.connect(depositor).flashWBurnBuyLong(vaultId, vaultBefore.shortAmount, vaultBefore.collateralAmount, BigNumber.from(0));
+      console.log("squeethPrice", squeethPrice.toString())
+      console.log("squeethToBuy", squeethToBuy.toString())
+
+      await controllerHelper.connect(depositor).flashswapWBurnBuyLong(vaultId, vaultBefore.shortAmount, squeethToBuy, vaultBefore.collateralAmount, vaultBefore.collateralAmount);
 
       const vaultAfter = await controller.vaults(vaultId)
       const longBalanceAfter = await wSqueeth.balanceOf(depositor.address)
 
       expect(vaultAfter.shortAmount.eq(BigNumber.from(0))).to.be.true
       expect(vaultAfter.collateralAmount.eq(BigNumber.from(0))).to.be.true
-      expect(longBalanceAfter.gt(longBalanceBefore)).to.be.true
+      // expect(longBalanceAfter.gt(longBalanceBefore)).to.be.true
+      expect(longBalanceAfter.sub(longBalanceBefore).eq(squeethToBuy)).to.be.true
     })
   })
 })

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -106,7 +106,6 @@ describe("Controller helper integration test", function () {
   describe("Mint short with flash deposit", async () => {
     it("flash mint", async () => {      
       const vaultId = await shortSqueeth.nextId();
-      // await controller.connect(depositor).updateOperator(vaultId, controllerHelper.address)
 
       const normFactor = await controller.normalizationFactor()
       const mintWSqueethAmount = ethers.utils.parseUnits('10')

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -157,9 +157,6 @@ describe("Controller helper integration test", function () {
       const squeethPrice = await oracle.getTwap(wSqueethPool.address, wSqueeth.address, weth.address, 420, true)
       const squeethToBuy = vaultBefore.collateralAmount.div(squeethPrice)
 
-      console.log("squeethPrice", squeethPrice.toString())
-      console.log("squeethToBuy", squeethToBuy.toString())
-
       await controllerHelper.connect(depositor).flashswapWBurnBuyLong(vaultId, vaultBefore.shortAmount, squeethToBuy, vaultBefore.collateralAmount, vaultBefore.collateralAmount);
 
       const vaultAfter = await controller.vaults(vaultId)
@@ -167,7 +164,6 @@ describe("Controller helper integration test", function () {
 
       expect(vaultAfter.shortAmount.eq(BigNumber.from(0))).to.be.true
       expect(vaultAfter.collateralAmount.eq(BigNumber.from(0))).to.be.true
-      // expect(longBalanceAfter.gt(longBalanceBefore)).to.be.true
       expect(longBalanceAfter.sub(longBalanceBefore).eq(squeethToBuy)).to.be.true
     })
   })

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -105,6 +105,9 @@ describe("Controller helper integration test", function () {
 
   describe("Mint short with flash deposit", async () => {
     it("flash mint", async () => {      
+      const vaultId = await shortSqueeth.nextId();
+      // await controller.connect(depositor).updateOperator(vaultId, controllerHelper.address)
+
       const normFactor = await controller.normalizationFactor()
       const mintWSqueethAmount = ethers.utils.parseUnits('10')
       const mintRSqueethAmount = mintWSqueethAmount.mul(normFactor).div(one)

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -155,7 +155,7 @@ describe("Controller helper integration test", function () {
       const vaultBefore = await controller.vaults(vaultId)
       const longBalanceBefore = await wSqueeth.balanceOf(depositor.address)
 
-      await controllerHelper.connect(depositor).flashWBurn(vaultId, vaultBefore.shortAmount, vaultBefore.collateralAmount, BigNumber.from(0));
+      await controllerHelper.connect(depositor).flashWBurnBuyLong(vaultId, vaultBefore.shortAmount, vaultBefore.collateralAmount, BigNumber.from(0));
 
       const vaultAfter = await controller.vaults(vaultId)
       const longBalanceAfter = await wSqueeth.balanceOf(depositor.address)

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -105,8 +105,6 @@ describe("Controller helper integration test", function () {
 
   describe("Mint short with flash deposit", async () => {
     it("flash mint", async () => {      
-      const vaultId = await shortSqueeth.nextId();
-
       const normFactor = await controller.normalizationFactor()
       const mintWSqueethAmount = ethers.utils.parseUnits('10')
       const mintRSqueethAmount = mintWSqueethAmount.mul(normFactor).div(one)


### PR DESCRIPTION
# feat: flash close short and buy long

## Description

This PR add the feature of closing a short position and buying WPowerPerp with the remaining funds.
The `flashWBurnBuyLong()` will:
- flashswap WPowerPerp token
- close the short position
- Remove collateral and repay flashswap
- Long WPowerPerp token using remaining ETH

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
