### PR TITLE
fix(nav): Update link from opyn to squeeth

### DIFF
--- a/packages/frontend/src/components/Nav.tsx
+++ b/packages/frontend/src/components/Nav.tsx
@@ -107,7 +107,7 @@ const Nav: React.FC = () => {
   return (
     <div className={classes.nav}>
       <div className={classes.logo}>
-        <a href="https://opyn.co/">
+        <a href="https://squeeth.opyn.co/">
           <Image src={logo} alt="logo" width={127} height={55} />
         </a>
       </div>


### PR DESCRIPTION
## Description

I found it strange that the Squeeth logo in the nav redirected to https://www.opyn.co/ instead of https://squeeth.opyn.co so I fixed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

It hasn't

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
