### PR TITLE
Fix Pnl loading issues

### DIFF
--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -17,6 +17,8 @@ import { PositionsProvider } from '@context/positions'
 import getTheme, { Mode } from '../src/theme'
 import { uniswapClient } from '@utils/apollo-client'
 
+const queryClient = new QueryClient()
+
 function MyApp({ Component, pageProps }: any) {
   const router = useRouter()
 
@@ -28,7 +30,6 @@ function MyApp({ Component, pageProps }: any) {
     }
   }, [])
 
-  const queryClient = new QueryClient()
   const siteID = process.env.NEXT_PUBLIC_FATHOM_CODE ? process.env.NEXT_PUBLIC_FATHOM_CODE : ''
 
   useEffect(() => {
@@ -55,13 +56,13 @@ function MyApp({ Component, pageProps }: any) {
 
   return (
     <CookiesProvider>
-      <WalletProvider>
-        <RestrictUserProvider>
-          <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        <WalletProvider>
+          <RestrictUserProvider>
             <TradeApp Component={Component} pageProps={pageProps} />
-          </QueryClientProvider>
-        </RestrictUserProvider>
-      </WalletProvider>
+          </RestrictUserProvider>
+        </WalletProvider>
+      </QueryClientProvider>
     </CookiesProvider>
   )
 }

--- a/packages/frontend/pages/positions.tsx
+++ b/packages/frontend/pages/positions.tsx
@@ -333,7 +333,7 @@ export function Positions() {
                   {isPositionLoading ||
                   shortGain.isLessThanOrEqualTo(-100) ||
                   !shortGain.isFinite() ||
-                  longUnrealizedPNL.loading ? (
+                  shortUnrealizedPNL.loading ? (
                     <Typography variant="body1">Loading</Typography>
                   ) : (
                     <>

--- a/packages/frontend/src/context/wallet.tsx
+++ b/packages/frontend/src/context/wallet.tsx
@@ -10,6 +10,7 @@ import { EtherscanPrefix } from '../constants'
 import useInterval from '@hooks/useInterval'
 import { Networks } from '../types'
 import { Web3Provider } from '@ethersproject/providers'
+import { useQueryClient } from 'react-query'
 
 const useAlchemy = process.env.NEXT_PUBLIC_USE_ALCHEMY
 const defaultWeb3 = useAlchemy
@@ -52,6 +53,8 @@ const WalletProvider: React.FC = ({ children }) => {
   const [signer, setSigner] = useState<any>(null)
   const [balance, setBalance] = useState<BigNumber>(new BigNumber(0))
 
+  const queryClient = useQueryClient()
+
   const onWalletSelect = useCallback(async () => {
     if (!onboard) return
     onboard.walletSelect().then((success) => {
@@ -62,6 +65,7 @@ const WalletProvider: React.FC = ({ children }) => {
   const disconnectWallet = useCallback(async () => {
     if (!onboard) return
     await onboard.walletReset()
+    queryClient.removeQueries()
     setAddress(null)
     setBalance(new BigNumber(0))
   }, [onboard])

--- a/packages/frontend/src/hooks/useETHPrice.ts
+++ b/packages/frontend/src/hooks/useETHPrice.ts
@@ -56,7 +56,9 @@ export const getHistoricEthPrice = async (dateString: string): Promise<BigNumber
     `https://api.twelvedata.com/time_series?start_date=${dateString}&end_date=${dateString}&symbol=${pair}&interval=1min&apikey=${process.env.NEXT_PUBLIC_TWELVEDATA_APIKEY}`,
   ).then((res) => res.json())
 
-  if (response.status === 'error') return new BigNumber(0)
+  if (response.status === 'error') {
+    throw new Error(response.status)
+  }
 
   return new BigNumber(Number(response.values[0].close))
 }

--- a/packages/frontend/src/hooks/usePositions.ts
+++ b/packages/frontend/src/hooks/usePositions.ts
@@ -122,13 +122,10 @@ export const usePnL = () => {
           buyQuote,
           toTokenAmount(index, 18).sqrt(),
           squeethAmount,
+          ethCollateralPnl,
         )
         setShortUnrealizedPNL({
-          usd: pnl.plus(ethCollateralPnl),
-          eth: pnl.plus(ethCollateralPnl).div(toTokenAmount(index, 18).sqrt()).isFinite()
-            ? pnl.plus(ethCollateralPnl).div(toTokenAmount(index, 18).sqrt())
-            : BIG_ZERO,
-          loading: false,
+          ...pnl,
         })
       } else {
         setShortUnrealizedPNL((prevState) => ({ ...prevState, loading: true }))
@@ -153,7 +150,7 @@ export const usePnL = () => {
           toTokenAmount(index, 18).sqrt(),
           squeethAmount,
         )
-        setLongUnrealizedPNL((prevState) => ({ ...prevState, ...pnl, loading: false }))
+        setLongUnrealizedPNL((prevState) => ({ ...prevState, ...pnl }))
       } else {
         setLongUnrealizedPNL((prevState) => ({ ...prevState, loading: true }))
       }

--- a/packages/frontend/src/hooks/usePositions.ts
+++ b/packages/frontend/src/hooks/usePositions.ts
@@ -64,12 +64,12 @@ export const usePnL = () => {
 
   useEffect(() => {
     ;(async () => {
-      if (vaultHistory?.length && !index.isZero() && !existingCollat.isZero()) {
+      if (vaultHistory?.length && !index.isZero() && !existingCollat.isZero() && swaps?.length) {
         const result = await calcETHCollateralPnl(vaultHistory, toTokenAmount(index, 18).sqrt(), existingCollat)
         setEthCollateralPnl(result)
       }
     })()
-  }, [index.toString(), existingCollat.toString(), vaultHistory?.length])
+  }, [index.toString(), existingCollat.toString(), vaultHistory?.length, swaps?.length])
 
   useEffect(() => {
     if (!ready || positionLoading) return
@@ -109,8 +109,20 @@ export const usePnL = () => {
 
   useEffect(() => {
     ;(async () => {
-      if (swaps?.length && !buyQuote.isZero() && !index.isZero() && !ethCollateralPnl.isZero()) {
-        const pnl = await calcDollarShortUnrealizedpnl(swaps, isWethToken0, buyQuote, toTokenAmount(index, 18).sqrt())
+      if (
+        swaps?.length &&
+        !buyQuote.isZero() &&
+        !index.isZero() &&
+        !ethCollateralPnl.isZero() &&
+        !squeethAmount.isZero()
+      ) {
+        const pnl = await calcDollarShortUnrealizedpnl(
+          swaps,
+          isWethToken0,
+          buyQuote,
+          toTokenAmount(index, 18).sqrt(),
+          squeethAmount,
+        )
         setShortUnrealizedPNL({
           usd: pnl.plus(ethCollateralPnl),
           eth: pnl.plus(ethCollateralPnl).div(toTokenAmount(index, 18).sqrt()).isFinite()
@@ -122,18 +134,31 @@ export const usePnL = () => {
         setShortUnrealizedPNL((prevState) => ({ ...prevState, loading: true }))
       }
     })()
-  }, [buyQuote.toString(), ethCollateralPnl.toString(), index.toString(), isWethToken0, swaps?.length])
+  }, [
+    buyQuote.toString(),
+    ethCollateralPnl.toString(),
+    index.toString(),
+    isWethToken0,
+    swaps?.length,
+    squeethAmount.toString(),
+  ])
 
   useEffect(() => {
     ;(async () => {
-      if (swaps?.length && !sellQuote.amountOut.isZero() && !index.isZero()) {
-        const pnl = await calcDollarLongUnrealizedpnl(swaps, isWethToken0, sellQuote, toTokenAmount(index, 18).sqrt())
+      if (swaps?.length && !sellQuote.amountOut.isZero() && !index.isZero() && !squeethAmount.isZero()) {
+        const pnl = await calcDollarLongUnrealizedpnl(
+          swaps,
+          isWethToken0,
+          sellQuote,
+          toTokenAmount(index, 18).sqrt(),
+          squeethAmount,
+        )
         setLongUnrealizedPNL((prevState) => ({ ...prevState, ...pnl, loading: false }))
       } else {
         setLongUnrealizedPNL((prevState) => ({ ...prevState, loading: true }))
       }
     })()
-  }, [index.toString(), isWethToken0, sellQuote.amountOut.toString(), swaps?.length])
+  }, [index.toString(), isWethToken0, sellQuote.amountOut.toString(), swaps?.length, squeethAmount.toString()])
 
   return {
     longGain,

--- a/packages/frontend/src/lib/pnl.ts
+++ b/packages/frontend/src/lib/pnl.ts
@@ -144,7 +144,13 @@ export async function calcDollarShortUnrealizedpnl(
     return acc
   }, Promise.resolve({ totalWethInUSD: BIG_ZERO, totalSqueeth: BIG_ZERO, priceError: false }))
 
-  return !priceError ? totalWethInUSD.minus(buyQuote.times(uniswapEthPrice)) : BIG_ZERO
+  const usd = totalWethInUSD.minus(buyQuote.times(uniswapEthPrice))
+
+  return {
+    usd,
+    eth: usd.plus(ethCollateralPnl).div(uniswapEthPrice),
+    loading: priceError,
+  }
 }
 
 export async function calcDollarLongUnrealizedpnl(
@@ -185,6 +191,7 @@ export async function calcDollarLongUnrealizedpnl(
   return {
     usd: usdValue,
     eth: !usdValue.isZero() ? usdValue.div(uniswapEthPrice) : BIG_ZERO,
+    loading: priceError,
   }
 }
 
@@ -205,7 +212,7 @@ async function getEthPriceAtTransactionTime(timestamp: string) {
       historicPriceQueryKeys.historicPrice(timestamp),
       () => getETHWithinOneDayPrices(),
       {
-      staleTime: Infinity,
+        staleTime: Infinity,
       },
     )
 
@@ -219,7 +226,7 @@ async function getEthPriceAtTransactionTime(timestamp: string) {
         historicPriceQueryKeys.historicPrice(timestamp),
         () => getHistoricEthPrice(dateTimeString),
         {
-        staleTime: Infinity,
+          staleTime: Infinity,
         },
       )
     }
@@ -239,7 +246,7 @@ async function getEthPriceAtTransactionTime(timestamp: string) {
       historicPriceQueryKeys.historicPrice(timestamp),
       () => getHistoricEthPrice(dateTimeString),
       {
-      staleTime: Infinity,
+        staleTime: Infinity,
       },
     )
   }
@@ -251,7 +258,7 @@ async function getEthPriceAtTransactionTime(timestamp: string) {
     historicPriceQueryKeys.historicPrice(timestamp),
     () => getHistoricEthPrice(dateTimeString),
     {
-    staleTime: Infinity,
+      staleTime: Infinity,
     },
   )
 }

--- a/packages/frontend/src/lib/pnl.ts
+++ b/packages/frontend/src/lib/pnl.ts
@@ -177,6 +177,10 @@ export async function calcDollarLongUnrealizedpnl(
   }
 }
 
+const historicPriceQueryKeys = {
+  historicPrice: (timestamp: string) => [`userPrice_${timestamp}`],
+}
+
 async function getEthPriceAtTransactionTime(timestamp: string) {
   const timeInMilliseconds = new Date(Number(timestamp) * 1000).setUTCSeconds(0, 0)
   const currentTimeInMilliseconds = Date.now()
@@ -186,9 +190,13 @@ async function getEthPriceAtTransactionTime(timestamp: string) {
 
   if (diff < TWELVEDATA_NO_PRICEDATA_DURATION) {
     // call coingecko
-    const priceData = await queryClient.fetchQuery(`userPrice_${timestamp}`, () => getETHWithinOneDayPrices(), {
+    const priceData = await queryClient.fetchQuery(
+      historicPriceQueryKeys.historicPrice(timestamp),
+      () => getETHWithinOneDayPrices(),
+      {
       staleTime: Infinity,
-    })
+      },
+    )
 
     if (priceData.length === 1) {
       // call twelvedata
@@ -196,9 +204,13 @@ async function getEthPriceAtTransactionTime(timestamp: string) {
         new Date(subMinutes(new Date(), TWELVEDATA_NO_PRICEDATA_DURATION)).setUTCSeconds(0),
         'yyyy-MM-dd HH:mm:ss',
       )
-      return await queryClient.fetchQuery(`userPrice_${timestamp}`, () => getHistoricEthPrice(dateTimeString), {
+      return await queryClient.fetchQuery(
+        historicPriceQueryKeys.historicPrice(timestamp),
+        () => getHistoricEthPrice(dateTimeString),
+        {
         staleTime: Infinity,
-      })
+        },
+      )
     }
 
     const dateList = priceData.map((item) => item.time)
@@ -212,15 +224,23 @@ async function getEthPriceAtTransactionTime(timestamp: string) {
       new Date(subMinutes(new Date(), TWELVEDATA_NO_PRICEDATA_DURATION)).setUTCSeconds(0),
       'yyyy-MM-dd HH:mm:ss',
     )
-    return await queryClient.fetchQuery(`userPrice_${timestamp}`, () => getHistoricEthPrice(dateTimeString), {
+    return await queryClient.fetchQuery(
+      historicPriceQueryKeys.historicPrice(timestamp),
+      () => getHistoricEthPrice(dateTimeString),
+      {
       staleTime: Infinity,
-    })
+      },
+    )
   }
 
   // call twelvedata
   const dateTimeString = format(new Date(timeInMilliseconds), 'yyyy-MM-dd HH:mm:ss')
 
-  return await queryClient.fetchQuery(`userPrice_${timestamp}`, () => getHistoricEthPrice(dateTimeString), {
+  return await queryClient.fetchQuery(
+    historicPriceQueryKeys.historicPrice(timestamp),
+    () => getHistoricEthPrice(dateTimeString),
+    {
     staleTime: Infinity,
-  })
+    },
+  )
 }

--- a/packages/frontend/src/lib/pnl.ts
+++ b/packages/frontend/src/lib/pnl.ts
@@ -82,7 +82,19 @@ export async function calcETHCollateralPnl(
       }, Promise.resolve({ deposits: BIG_ZERO, withdrawals: BIG_ZERO }))
     : { deposits: BIG_ZERO, withdrawals: BIG_ZERO }
 
-  return currentVaultEthBalance.times(uniswapEthPrice).minus(deposits.minus(withdrawals))
+const getRelevantSwaps = (squeethAmount: BigNumber, swaps: swaps_swaps[], isWethToken0: boolean, isLong = false) => {
+  let totalSqueeth = BIG_ZERO
+  const relevantSwaps = []
+  for (let index = swaps.length - 1; index >= 0; index--) {
+    const squeethAmt = new BigNumber(isWethToken0 ? swaps[index].amount1 : swaps[index].amount0)
+    const sqthAmount = isLong ? squeethAmt.negated() : squeethAmt
+    totalSqueeth = totalSqueeth.plus(sqthAmount)
+    relevantSwaps.push(swaps[index])
+    if (squeethAmount.isEqualTo(totalSqueeth)) {
+      break
+    }
+  }
+  return relevantSwaps
 }
 
 export async function calcDollarShortUnrealizedpnl(


### PR DESCRIPTION
# Task:

## Description

> I found that the issue was because sometimes the historic price(twelvedata) data is not being fetched cos the number of calls exceeds our limit per minute. I was getting `{"code":429,"message":"You have run out of API credits for the current minute. 663 API credits were used, with the current limit being 377. Wait for the next minute or consider switching to a higher tier plan at https://twelvedata.com/pricing","status":"error”}` error and historic price was returning zero when that happened.

> What I have done is ;

- Reduce the number of calls being made per user by ensuring that we only fetch the historic price for swaps that are relevant to the current user's position (see getRelevantSwaps lib/pnl.ts), and cache fetched historic price so that it doesn't keep calling the endpoint for every re-render.
- Invalidate the pnl calculation if historic ethPrice is not fetched, so it will not show any pnl if it’s unable to fetch historic ethPrice. This will ensure that we are not giving the user the wrong information.

Fixes # (issue)
#177 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
