### PR TITLE
feat: fix settings menu issue

### DIFF
--- a/packages/frontend/src/components/SettingsMenu.tsx
+++ b/packages/frontend/src/components/SettingsMenu.tsx
@@ -95,12 +95,12 @@ const SettingMenu = () => {
           'aria-labelledby': 'nav-menu-button',
         }}
       >
-        <MenuItem onClick={handleClose}>
+        <MenuItem onClick={handleClose} key="discord">
           <a href="https://tiny.cc/opyndiscord" target="_blank" rel="noopener noreferrer">
             Discord
           </a>
         </MenuItem>
-        <MenuItem onClick={handleClose}>
+        <MenuItem onClick={handleClose} key="docs">
           <a href="https://opyn.gitbook.io/squeeth/" target="_blank" rel="noopener noreferrer">
             Docs
           </a>

--- a/packages/frontend/src/components/SettingsMenu.tsx
+++ b/packages/frontend/src/components/SettingsMenu.tsx
@@ -21,6 +21,10 @@ const useStyles = makeStyles((theme) =>
       marginTop: theme.spacing(1),
       minWidth: 180,
     },
+    link: {
+      display: 'flex',
+      width: '100%',
+    },
     legalModal: {
       margin: '8em auto 0px',
       width: '90%',
@@ -96,12 +100,12 @@ const SettingMenu = () => {
         }}
       >
         <MenuItem onClick={handleClose} key="discord">
-          <a href="https://tiny.cc/opyndiscord" target="_blank" rel="noopener noreferrer">
+          <a href="https://tiny.cc/opyndiscord" target="_blank" rel="noopener noreferrer" className={classes.link}>
             Discord
           </a>
         </MenuItem>
-        <MenuItem onClick={handleClose} key="docs">
-          <a href="https://opyn.gitbook.io/squeeth/" target="_blank" rel="noopener noreferrer">
+        <MenuItem onClick={handleClose}>
+          <a href="https://opyn.gitbook.io/squeeth/" target="_blank" rel="noopener noreferrer" className={classes.link}>
             Docs
           </a>
         </MenuItem>


### PR DESCRIPTION
# Task:

## Description
no response after clicking the doc menu item in prod
Add key for menu item to fix it.

<img width="555" alt="image" src="https://user-images.githubusercontent.com/3824034/159109036-dd7a12c0-0a47-4fee-b3ef-bbe4388f9128.png">


Fixes # (issue)
#251 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

- Go to https://squeeth.opyn.co/
- Click on ... on top right of page
- Click "Docs" item
## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
