### PR TITLE
feat: add embed image for twitter preview

### DIFF
--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -91,6 +91,16 @@ const TradeApp = ({ Component, pageProps }: any) => {
           name="description"
           content="Squeeth is a new financial primitive in DeFi that gives traders exposure to ETH²"
         />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Squeeth" />
+        <meta
+          name="twitter:description"
+          content="Squeeth is a new financial primitive in DeFi that gives traders exposure to ETH²"
+        />
+        <meta
+          name="twitter:image"
+          content="https://squeeth.opyn.co/_next/image?url=%2F_next%2Fstatic%2Fmedia%2FSqueethLogo.f8b5e88c.svg&w=128&q=75"
+        />
         <link rel="icon" href="/favicon.ico" />
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
       </Head>

--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -97,10 +97,7 @@ const TradeApp = ({ Component, pageProps }: any) => {
           name="twitter:description"
           content="Squeeth is a new financial primitive in DeFi that gives traders exposure to ETH²"
         />
-        <meta
-          name="twitter:image"
-          content="https://squeeth.opyn.co/_next/image?url=%2F_next%2Fstatic%2Fmedia%2FSqueethLogo.f8b5e88c.svg&w=128&q=75"
-        />
+        <meta name="twitter:image" content="https://squeeth.opyn.co/images/SqueethLogoMedium.png" />
         <link rel="icon" href="/favicon.ico" />
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
       </Head>


### PR DESCRIPTION
# Task:

## Description
Add embed image to head section of page to enable preview when squeeth is shared in twitter.

> A URL to a unique image representing the content of the page. You should not use a generic image such as your website logo, author photo, or other image that spans multiple pages. Images for this Card support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported.


Fixes #218 (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
