### PR TITLE
Custom hooks for handling bignumber depdancy

### DIFF
--- a/packages/frontend/.eslintrc
+++ b/packages/frontend/.eslintrc
@@ -44,7 +44,12 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/camelcase": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "(useAppEffect|useAppMemo|useAppCallback)"
+      }
+    ],
     "react/prop-types": "off",
     "import/order": "off",
     "sort-imports": "off",

--- a/packages/frontend/src/components/PositionCard.tsx
+++ b/packages/frontend/src/components/PositionCard.tsx
@@ -40,6 +40,9 @@ import {
 } from 'src/state/pnl/hooks'
 import { loadingAtom } from 'src/state/pnl/atoms'
 import { useVaultData } from '@hooks/useVaultData'
+import useAppEffect from '@hooks/useAppEffect'
+import useAppCallback from '@hooks/useAppCallback'
+import useAppMemo from '@hooks/useAppMemo'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -223,7 +226,7 @@ const PositionCard: React.FC = () => {
     return shortVaults.length && shortVaults[firstValidVault]?.shortAmount?.isZero() && liquidations.length > 0
   }, [firstValidVault, shortVaults?.length, liquidations?.length])
 
-  const isDollarValueLoading = useMemo(() => {
+  const isDollarValueLoading = useAppMemo(() => {
     if (positionType === PositionType.LONG) {
       return loading || longGain.isLessThanOrEqualTo(-100) || !longGain.isFinite()
     } else if (positionType === PositionType.SHORT) {
@@ -231,9 +234,9 @@ const PositionCard: React.FC = () => {
     } else {
       return null
     }
-  }, [positionType, loading, longGain.toString(), shortGain.toString()])
+  }, [positionType, loading, longGain, shortGain])
 
-  const getPositionBasedValue = useCallback(
+  const getPositionBasedValue = useAppCallback(
     (long: any, short: any, none: any, loadingMsg?: any) => {
       if (loadingMsg && (loading || isPositionLoading)) return loadingMsg
       if (positionType === PositionType.LONG) {
@@ -252,10 +255,10 @@ const PositionCard: React.FC = () => {
       }
       return none
     },
-    [isPositionLoading, loading, positionType, longGain.toString(), shortGain.toString()],
+    [isPositionLoading, loading, positionType, longGain, shortGain],
   )
 
-  const getRealizedPNLBasedValue = useCallback(
+  const getRealizedPNLBasedValue = useAppCallback(
     (long: any, short: any, none: any, loadingMsg?: any) => {
       if (loadingMsg && loading) return loadingMsg
       if (longRealizedPNL.isEqualTo(0) && shortRealizedPNL.isEqualTo(0)) return none
@@ -263,10 +266,10 @@ const PositionCard: React.FC = () => {
       if (positionType === PositionType.SHORT) return short
       return none
     },
-    [tradeSuccess, positionType, loading, longRealizedPNL.toString(), shortRealizedPNL.toString()],
+    [positionType, loading, longRealizedPNL, shortRealizedPNL],
   )
 
-  useEffect(() => {
+  useAppEffect(() => {
     if (isPositionLoading) return
 
     let _postTradeAmt = new BigNumber(0)
@@ -291,14 +294,7 @@ const PositionCard: React.FC = () => {
 
     setPostTradeAmt(_postTradeAmt)
     setPostPosition(_postPosition)
-  }, [
-    actualTradeType,
-    isOpenPosition,
-    isPositionLoading,
-    positionType,
-    squeethAmount.toString(),
-    tradeAmount.toString(),
-  ])
+  }, [actualTradeType, isOpenPosition, isPositionLoading, positionType, squeethAmount, tradeAmount])
 
   const pnlLoading = useMemo(() => {
     if (positionType === PositionType.LONG) {

--- a/packages/frontend/src/hooks/useAppCallback.tsx
+++ b/packages/frontend/src/hooks/useAppCallback.tsx
@@ -1,0 +1,8 @@
+import stringifyBigNumDeps from '@utils/stringifyBigNumDeps'
+import { useCallback } from 'react'
+import { DependencyList } from 'react'
+
+export default function useAppCallback<T extends (...args: any[]) => any>(callback: T, deps: DependencyList) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useCallback(callback, stringifyBigNumDeps(deps) ?? [])
+}

--- a/packages/frontend/src/hooks/useAppEffect.tsx
+++ b/packages/frontend/src/hooks/useAppEffect.tsx
@@ -1,0 +1,9 @@
+import stringifyBigNumDeps from '@utils/stringifyBigNumDeps'
+import { useEffect } from 'react'
+import { DependencyList } from 'react'
+import { EffectCallback } from 'react'
+
+export default function useAppEffect(effect: EffectCallback, deps?: DependencyList) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(effect, stringifyBigNumDeps(deps))
+}

--- a/packages/frontend/src/hooks/useAppMemo.tsx
+++ b/packages/frontend/src/hooks/useAppMemo.tsx
@@ -1,0 +1,8 @@
+import stringifyBigNumDeps from '@utils/stringifyBigNumDeps'
+import { useMemo } from 'react'
+import { DependencyList } from 'react'
+
+export default function useAppMemo<T>(factory: () => T, deps?: DependencyList) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(factory, stringifyBigNumDeps(deps))
+}

--- a/packages/frontend/src/utils/stringifyBigNumDeps.ts
+++ b/packages/frontend/src/utils/stringifyBigNumDeps.ts
@@ -1,0 +1,6 @@
+import BigNumber from 'bignumber.js'
+import { DependencyList } from 'react'
+
+export default function stringifyBigNumDeps(deps?: DependencyList) {
+  return deps?.map((dep) => (dep instanceof BigNumber ? dep.toString() : dep))
+}


### PR DESCRIPTION
# Task:

## Description
We used to have an eslint issue using a stringified version of Big number inside hooks dependency.
![image](https://user-images.githubusercontent.com/59410529/160653557-4000572e-90f0-44aa-a4b7-d1781d0af6f8.png)
The big number can't be used as a dependency directly because it's an object, and lint shouldn't complain about a stringified big number. So, we tend to ignore dependency lint issues and sometimes miss necessary dependency though lint catches it, which causes critical UI bugs. 

This PR introduces useAppEffect, useAppMemo, useAppCallback, which you can pass Big number as a dependency directly without string conversion.
![image](https://user-images.githubusercontent.com/59410529/160655124-933d0545-d956-44a5-bc0b-ae190bc60743.png)
If you miss a necessary dependency, lint will complain about it. We shouldn't ignore any lint issues in new hooks.


Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
