### PR TITLE
fix: remove unnecessary vaultId checks

### DIFF
--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -83,11 +83,9 @@ contract ControllerHelper is UniswapControllerHelper, AaveControllerHelper, IERC
         external
         payable
     {
-        if (_params.vaultId != 0)
-            require(
-                IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) ==
-                    msg.sender
-            );
+        require(
+            IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) == msg.sender
+        );
         require(_params.maxToPay <= _params.collateralToWithdraw.add(msg.value));
 
         _exactOutFlashSwap(
@@ -144,11 +142,9 @@ contract ControllerHelper is UniswapControllerHelper, AaveControllerHelper, IERC
      * @param _params ControllerHelperDataType.CloseShortWithUserNftParams struct
      */
     function closeShortWithUserNft(ControllerHelperDataType.CloseShortWithUserNftParams calldata _params) external {
-        if (_params.vaultId != 0)
-            require(
-                IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) ==
-                    msg.sender
-            );
+        require(
+            IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) == msg.sender
+        );
 
         INonfungiblePositionManager(ControllerHelperDiamondStorage.getAddressAtSlot(6)).safeTransferFrom(
             msg.sender,
@@ -197,11 +193,9 @@ contract ControllerHelper is UniswapControllerHelper, AaveControllerHelper, IERC
         external
         payable
     {
-        if (_params.vaultId != 0)
-            require(
-                IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) ==
-                    msg.sender
-            );
+        require(
+            IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) == msg.sender
+        );
 
         _flashLoan(
             ControllerHelperDiamondStorage.getAddressAtSlot(5),


### PR DESCRIPTION
# fix: remove unnecessary vaultId checks

## Description

This remove the if statements to check if passed vaultID as param is different than 0 for functions that will not be used with vaultId == 0.


Fixes #293 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
