### PR TITLE
wrap/unwrap ETH pattern

### DIFF
--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -106,7 +106,10 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             abi.encode(_params)
         );
 
-        payable(msg.sender).sendValue(address(this).balance);
+        ControllerHelperUtil.sendBack(
+            ControllerHelperDiamondStorage.getAddressAtSlot(5),
+            ControllerHelperDiamondStorage.getAddressAtSlot(4)
+        );
     }
 
     /**
@@ -140,7 +143,10 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             uint8(ControllerHelperDataType.CALLBACK_SOURCE.FLASH_SELL_LONG_W_MINT),
             abi.encode(_params)
         );
-        payable(msg.sender).sendValue(address(this).balance);
+        ControllerHelperUtil.sendBack(
+            ControllerHelperDiamondStorage.getAddressAtSlot(5),
+            ControllerHelperDiamondStorage.getAddressAtSlot(4)
+        );
     }
 
     /**
@@ -189,7 +195,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             _params.collateralToWithdraw,
             _params.limitPriceEthPerPowerPerp
         );
-        wrapInternal(_params.collateralToWithdraw);
+        wrapInternal(address(this).balance);
 
         ControllerHelperUtil.sendBack(
             ControllerHelperDiamondStorage.getAddressAtSlot(5),
@@ -734,14 +740,21 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                 _callData,
                 (ControllerHelperDataType.FlashswapWBurnBuyLongParams)
             );
-            IController(ControllerHelperDiamondStorage.getAddressAtSlot(0)).burnWPowerPerpAmount(
+            // IController(ControllerHelperDiamondStorage.getAddressAtSlot(0)).burnWPowerPerpAmount(
+            //     data.vaultId,
+            //     data.wPowerPerpAmountToBurn,
+            //     data.collateralToWithdraw
+            // );
+
+            ControllerHelperUtil.withdrawFromVault(
+                ControllerHelperDiamondStorage.getAddressAtSlot(0),
+                ControllerHelperDiamondStorage.getAddressAtSlot(5),
                 data.vaultId,
                 data.wPowerPerpAmountToBurn,
                 data.collateralToWithdraw
             );
 
-
-            IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).deposit{value: _amountToPay}();
+            // IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).deposit{value: _amountToPay}();
             IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
                 ControllerHelperDiamondStorage.getAddressAtSlot(3),
                 _amountToPay

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -256,7 +256,10 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                 vaultId
             );
 
-        payable(msg.sender).sendValue(address(this).balance);
+        ControllerHelperUtil.sendBack(
+            ControllerHelperDiamondStorage.getAddressAtSlot(5),
+            ControllerHelperDiamondStorage.getAddressAtSlot(4)
+        );
     }
 
     /**

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -95,7 +95,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
         require(_params.maxToPay <= _params.collateralToWithdraw.add(msg.value));
 
         wrapInternal(msg.value);
-        
+
         _exactOutFlashSwap(
             ControllerHelperDiamondStorage.getAddressAtSlot(5),
             ControllerHelperDiamondStorage.getAddressAtSlot(4),
@@ -273,7 +273,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                 IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) ==
                     msg.sender
             );
-        
+
         wrapInternal(msg.value);
         _flashLoan(
             ControllerHelperDiamondStorage.getAddressAtSlot(5),

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -790,7 +790,8 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                 _amountToPay
             );
 
-            if (address(this).balance > 0) IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).deposit{value: address(this).balance}();
+            if (address(this).balance > 0)
+                IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).deposit{value: address(this).balance}();
         } else if (
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTOUT_ETH_WPOWERPERP

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -269,9 +269,9 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
 
     /**
      * @notice sell all LP wPowerPerp amounts to WETH and send back to user
-     * @param _params ControllerHelperDataType.SellAll struct
+     * @param _params ControllerHelperDataType.ReduceLiquidityAndSell struct
      */
-    function sellAll(ControllerHelperDataType.SellAll calldata _params) external {
+    function reduceLiquidityAndSell(ControllerHelperDataType.ReduceLiquidityAndSell calldata _params) external {
         INonfungiblePositionManager(ControllerHelperDiamondStorage.getAddressAtSlot(6)).safeTransferFrom(
             msg.sender,
             address(this),
@@ -284,7 +284,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             ControllerHelperDataType.closeUniLpParams({
                 tokenId: _params.tokenId,
                 liquidity: _params.liquidity,
-                liquidityPercentage: 1e18,
+                liquidityPercentage: _params.liquidityPercentage,
                 amount0Min: uint128(_params.amount0Min),
                 amount1Min: uint128(_params.amount1Min)
             }),

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -291,6 +291,15 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             isWethToken0
         );
 
+        ControllerHelperUtil.checkClosedLp(
+            msg.sender,
+            ControllerHelperDiamondStorage.getAddressAtSlot(0),
+            ControllerHelperDiamondStorage.getAddressAtSlot(6),
+            0,
+            _params.tokenId,
+            _params.liquidityPercentage
+        );
+
         if (wPowerPerpAmountInLp > 0) {
             _exactInFlashSwap(
                 ControllerHelperDiamondStorage.getAddressAtSlot(4),

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -414,7 +414,6 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             0,
             ControllerHelperDataType.LpWPowerPerpPool({
                 recipient: msg.sender,
-                ethAmount: _params.ethAmountToLp,
                 amount0Desired: (isWethToken0) ? _params.wethAmountDesired : _params.wPowerPerpAmountDesired,
                 amount1Desired: (isWethToken0) ? _params.wPowerPerpAmountDesired : _params.wethAmountDesired,
                 amount0Min: _params.amount0DesiredMin,

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -154,7 +154,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
      * @dev user should approve this contract for Uni NFT transfer
      * @param _params ControllerHelperDataType.CloseShortWithUserNftParams struct
      */
-    function closeShortWithUserNft(ControllerHelperDataType.CloseShortWithUserNftParams calldata _params) external {
+    function closeShortWithUserNft(ControllerHelperDataType.CloseShortWithUserNftParams calldata _params) external payable {
         require(
             IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) == msg.sender
         );
@@ -164,6 +164,8 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             address(this),
             _params.tokenId
         );
+
+        wrapInternal(msg.value);
 
         // close LP position
         (uint256 wPowerPerpAmountInLp, ) = ControllerHelperUtil.closeUniLp(

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -154,7 +154,10 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
      * @dev user should approve this contract for Uni NFT transfer
      * @param _params ControllerHelperDataType.CloseShortWithUserNftParams struct
      */
-    function closeShortWithUserNft(ControllerHelperDataType.CloseShortWithUserNftParams calldata _params) external payable {
+    function closeShortWithUserNft(ControllerHelperDataType.CloseShortWithUserNftParams calldata _params)
+        external
+        payable
+    {
         require(
             IShortPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(2)).ownerOf(_params.vaultId) == msg.sender
         );

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
@@ -139,7 +139,6 @@ library ControllerHelperDataType {
     /// @dev params for rebalanceWithoutVault()
     struct RebalanceWithoutVault {
         uint256 tokenId;    // Uni token ID
-        uint256 ethAmountToLp;  // amount of WETH to lp
         uint256 liquidity;  // LP liquidity amount
         uint256 wPowerPerpAmountDesired;    // wPowerPerp amount to LP
         uint256 wethAmountDesired;  // WETH amount to LP
@@ -155,7 +154,6 @@ library ControllerHelperDataType {
     /// @dev params for ControllerHelperUtil.lpWPowerPerpPool()
     struct LpWPowerPerpPool {
         address recipient;  // recipient address
-        uint256 ethAmount;  // ETH amount to LP
         uint256 amount0Desired; // amount to LP for asset0
         uint256 amount1Desired; // amount to LP for asset1
         uint256 amount0Min; // amount min to LP for asset0

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
@@ -127,9 +127,10 @@ library ControllerHelperDataType {
     }
 
     /// @dev params for sellAll()
-    struct SellAll {
+    struct ReduceLiquidityAndSell {
         uint256 tokenId;    // Uni token ID
         uint256 liquidity;  // LP liquidity amount
+        uint256 liquidityPercentage; // percentage of liquidity to burn in LP position in decimals with 18 precision(e.g 60% = 0.6 = 6e17)
         uint128 amount0Min; // minimum amount of token0 to get from closing Uni LP
         uint128 amount1Min; // minimum amount of token1 to get from closing Uni LP
         uint256 limitPriceEthPerPowerPerp; // price limit for selling wPowerPerp

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
@@ -136,16 +136,17 @@ library ControllerHelperUtil {
     /**
      * @notice mint wPowerPerp in vault
      * @param _controller controller address
+     * @param _weth WETH address
      * @param _vaultId vault Id
-     * @param __wPowerPerpToMint amount of wPowerPerp to mint
+     * @param _wPowerPerpToMint amount of wPowerPerp to mint
      * @param _collateralToDeposit amount of collateral to deposit
      */
-    function mintIntoVault(address _controller, address _weth, uint256 _vaultId, uint256 __wPowerPerpToMint, uint256 _collateralToDeposit) public returns (uint256) {
+    function mintIntoVault(address _controller, address _weth, uint256 _vaultId, uint256 _wPowerPerpToMint, uint256 _collateralToDeposit) public returns (uint256) {
         IWETH9(_weth).withdraw(_collateralToDeposit);
 
         return (IController(_controller).mintWPowerPerpAmount{value: _collateralToDeposit}(
             _vaultId,
-            __wPowerPerpToMint,
+            _wPowerPerpToMint,
             0
         ));
     }
@@ -153,6 +154,7 @@ library ControllerHelperUtil {
     /**
      * @notice burn wPowerPerp or just withdraw collateral from vault (or both)
      * @param _controller controller address
+     * @param _weth WETH address
      * @param _weth weth address
      * @param _vaultId vault Id
      * @param _wPowerPerpToBurn amount of wPowerPerp to burn
@@ -258,6 +260,8 @@ library ControllerHelperUtil {
 
     /**
      * @notice send ETH and wPowerPerp
+     * @param _weth WETH address
+     * @param _wPowerPerp wPowerPerp address
      */
     function sendBack(address _weth, address _wPowerPerp) public {
         IWETH9(_weth).withdraw(IWETH9(_weth).balanceOf(address(this)));

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
@@ -140,7 +140,9 @@ library ControllerHelperUtil {
      * @param __wPowerPerpToMint amount of wPowerPerp to mint
      * @param _collateralToDeposit amount of collateral to deposit
      */
-    function mintIntoVault(address _controller, uint256 _vaultId, uint256 __wPowerPerpToMint, uint256 _collateralToDeposit) public returns (uint256) {
+    function mintIntoVault(address _controller, address _weth, uint256 _vaultId, uint256 __wPowerPerpToMint, uint256 _collateralToDeposit) public returns (uint256) {
+        IWETH9(_weth).withdraw(_collateralToDeposit);
+
         return (IController(_controller).mintWPowerPerpAmount{value: _collateralToDeposit}(
             _vaultId,
             __wPowerPerpToMint,
@@ -196,10 +198,6 @@ library ControllerHelperUtil {
             recipient: _params.recipient,
             deadline: block.timestamp
         });
-
-        // (uint256 tokenId, , , ) = INonfungiblePositionManager(_nonfungiblePositionManager).mint{value: _params.ethAmount}(
-        //     mintParams
-        // );
 
         (uint256 tokenId, , , ) = INonfungiblePositionManager(_nonfungiblePositionManager).mint(
             mintParams

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
@@ -89,7 +89,6 @@ library ControllerHelperUtil {
             _vaultId,
             ControllerHelperDataType.LpWPowerPerpPool({
                 recipient: _mintAndLpParams.recipient,
-                ethAmount: _mintAndLpParams.collateralToLp,
                 amount0Desired: _isWethToken0 ? _mintAndLpParams.collateralToLp : _mintAndLpParams.wPowerPerpAmount,
                 amount1Desired: _isWethToken0 ? _mintAndLpParams.wPowerPerpAmount : _mintAndLpParams.collateralToLp,
                 amount0Min: _mintAndLpParams.amount0Min,

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
@@ -71,7 +71,9 @@ library ControllerHelperUtil {
      * @param _isWethToken0 bool variable indicate if Weth token is token0 in Uniswap v3 weth/wPowerPerp pool
      * @return _vaultId and tokenId
      */
-    function mintAndLp(address _controller, address _nonfungiblePositionManager, address _wPowerPerp, address _wPowerPerpPool, ControllerHelperDataType.MintAndLpParams calldata _mintAndLpParams, bool _isWethToken0) public returns (uint256, uint256) {
+    function mintAndLp(address _controller, address _nonfungiblePositionManager, address _wPowerPerp, address _wPowerPerpPool, address _weth, ControllerHelperDataType.MintAndLpParams calldata _mintAndLpParams, bool _isWethToken0) public returns (uint256, uint256) {
+        IWETH9(_weth).withdraw(_mintAndLpParams.collateralToDeposit);
+        
         uint256 _vaultId = IController(_controller).mintWPowerPerpAmount{value: _mintAndLpParams.collateralToDeposit}(
             _mintAndLpParams.vaultId,
             _mintAndLpParams.wPowerPerpAmount,
@@ -192,7 +194,11 @@ library ControllerHelperUtil {
             deadline: block.timestamp
         });
 
-        (uint256 tokenId, , , ) = INonfungiblePositionManager(_nonfungiblePositionManager).mint{value: _params.ethAmount}(
+        // (uint256 tokenId, , , ) = INonfungiblePositionManager(_nonfungiblePositionManager).mint{value: _params.ethAmount}(
+        //     mintParams
+        // );
+
+        (uint256 tokenId, , , ) = INonfungiblePositionManager(_nonfungiblePositionManager).mint(
             mintParams
         );
 

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
@@ -163,7 +163,7 @@ library ControllerHelperUtil {
             _collateralToWithdraw
         );
 
-        if (_collateralToWithdraw > 0) IWETH9(_weth).deposit{_collateralToWithdraw}();
+        if (_collateralToWithdraw > 0) IWETH9(_weth).deposit{value: _collateralToWithdraw}();
     }
 
     /**

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperUtil.sol
@@ -151,16 +151,19 @@ library ControllerHelperUtil {
     /**
      * @notice burn wPowerPerp or just withdraw collateral from vault (or both)
      * @param _controller controller address
+     * @param _weth weth address
      * @param _vaultId vault Id
      * @param _wPowerPerpToBurn amount of wPowerPerp to burn
      * @param _collateralToWithdraw amount of collateral to withdraw
      */
-    function withdrawFromVault(address _controller, uint256 _vaultId, uint256 _wPowerPerpToBurn, uint256 _collateralToWithdraw) public {
+    function withdrawFromVault(address _controller, address _weth, uint256 _vaultId, uint256 _wPowerPerpToBurn, uint256 _collateralToWithdraw) public {
         IController(_controller).burnWPowerPerpAmount(
             _vaultId,
             _wPowerPerpToBurn,
             _collateralToWithdraw
         );
+
+        if (_collateralToWithdraw > 0) IWETH9(_weth).deposit{_collateralToWithdraw}();
     }
 
     /**

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -67,7 +67,6 @@ const config: HardhatUserConfig = {
   networks: {
     hardhat: {
       initialBaseFeePerGas: 0,
-      gasPrice: 0,
       saveDeployments: false, // only used in cicd to test deployments
       mining: {
         auto: true

--- a/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
+++ b/packages/hardhat/test/integration-tests/periphery/controller-helper.ts
@@ -1381,6 +1381,7 @@ describe("Controller helper integration test", function () {
       const params = {
         tokenId: tokenId,
         liquidity: positionBefore.liquidity,
+        liquidityPercentage: BigNumber.from(1).mul(BigNumber.from(10).pow(18)),
         amount0Min: 0,
         amount1Min: 0,
         limitPriceEthPerPowerPerp: limitPriceEthPerPowerPerp
@@ -1390,7 +1391,7 @@ describe("Controller helper integration test", function () {
 
       const depositorEthBalanceBefore = await provider.getBalance(depositor.address)
 
-      const tx = await controllerHelper.connect(depositor).sellAll(params);
+      const tx = await controllerHelper.connect(depositor).reduceLiquidityAndSell(params);
 
       const receipt = await tx.wait()
       const gasSpent = receipt.gasUsed.mul(receipt.effectiveGasPrice)


### PR DESCRIPTION
# wrap/unwrap ETH pattern

## Description

This PR will make sure only WETH is used during the execution of any of the ControllerHelper functionalities, it only unwrap to ETH and use it when depositing collateral into vault or when sending back funds to user at the end of the transaction.

- Wrap any sent ETH to WETH as fist step in any payable function
- Wrap any removed ETH from vault to WETH
- Unwrap WETH before any collateral deposit to vault
- Unwrap all WETH balance at the end of transaction to send back ETH to user

Fixes #334 #357 #358 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
