### PR TITLE
feat: add from and sender to subgraph vault history

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -54,6 +54,8 @@ enum Action {
 
 type VaultHistory @entity {
   id: ID!
+  from: Bytes!
+  sender: Bytes!
   txid: String!
   timestamp: BigInt!
   totalEthCollateralAmount: BigInt!

--- a/packages/subgraph/src/constants.ts
+++ b/packages/subgraph/src/constants.ts
@@ -3,6 +3,7 @@ import { getShortHelperAddr } from "./util";
 
 export const BIGINT_ONE = BigInt.fromI32(1);
 export const BIGINT_ZERO = BigInt.fromI32(0);
+export const EMPTY_ADDR = Address.empty();
 export const MAINNET_SHORT_HELPER_ADDR = Address.fromString(
   "0x3b4095D5ff0e629972CAAa50bd3004B09a1632C5"
 );

--- a/packages/subgraph/src/constants.ts
+++ b/packages/subgraph/src/constants.ts
@@ -3,6 +3,7 @@ import { getShortHelperAddr } from "./util";
 
 export const BIGINT_ONE = BigInt.fromI32(1);
 export const BIGINT_ZERO = BigInt.fromI32(0);
+export const EMPTY_ADDR = Address.fromString("");
 export const MAINNET_SHORT_HELPER_ADDR = Address.fromString(
   "0x3b4095D5ff0e629972CAAa50bd3004B09a1632C5"
 );

--- a/packages/subgraph/src/constants.ts
+++ b/packages/subgraph/src/constants.ts
@@ -3,7 +3,6 @@ import { getShortHelperAddr } from "./util";
 
 export const BIGINT_ONE = BigInt.fromI32(1);
 export const BIGINT_ZERO = BigInt.fromI32(0);
-export const EMPTY_ADDR = Address.fromString("");
 export const MAINNET_SHORT_HELPER_ADDR = Address.fromString(
   "0x3b4095D5ff0e629972CAAa50bd3004B09a1632C5"
 );

--- a/packages/subgraph/src/controller.ts
+++ b/packages/subgraph/src/controller.ts
@@ -37,12 +37,7 @@ import {
 } from "../generated/schema";
 import { loadOrCreateAccount } from "./util";
 
-import {
-  BIGINT_ONE,
-  BIGINT_ZERO,
-  EMPTY_ADDR,
-  SHORT_HELPER_ADDR,
-} from "./constants";
+import { BIGINT_ONE, BIGINT_ZERO, SHORT_HELPER_ADDR } from "./constants";
 
 // Note: If a handler doesn't require existing field values, it is faster
 // _not_ to load the entity from the store. Instead, create it fresh with
@@ -186,7 +181,7 @@ export function handleLiquidate(event: Liquidate): void {
   //update vault history
   const vaultTransaction = getTransactionDetail(
     event.transaction.from,
-    EMPTY_ADDR,
+    event.transaction.from,
     event.params.vaultId,
     event.params.collateralPaid,
     vault,

--- a/packages/subgraph/src/controller.ts
+++ b/packages/subgraph/src/controller.ts
@@ -37,7 +37,12 @@ import {
 } from "../generated/schema";
 import { loadOrCreateAccount } from "./util";
 
-import { BIGINT_ONE, BIGINT_ZERO, SHORT_HELPER_ADDR } from "./constants";
+import {
+  BIGINT_ONE,
+  BIGINT_ZERO,
+  EMPTY_ADDR,
+  SHORT_HELPER_ADDR,
+} from "./constants";
 
 // Note: If a handler doesn't require existing field values, it is faster
 // _not_ to load the entity from the store. Instead, create it fresh with
@@ -103,6 +108,8 @@ export function handleBurnShort(event: BurnShort): void {
   }
   //update vault history
   const vaultTransaction = getTransactionDetail(
+    event.transaction.from,
+    event.params.sender,
     event.params.vaultId,
     event.params.amount,
     vault,
@@ -126,6 +133,8 @@ export function handleDepositCollateral(event: DepositCollateral): void {
 
   //update vault history
   const vaultTransaction = getTransactionDetail(
+    event.transaction.from,
+    event.params.sender,
     event.params.vaultId,
     event.params.amount,
     vault,
@@ -176,6 +185,8 @@ export function handleLiquidate(event: Liquidate): void {
   let transactionHash = event.transaction.hash.toHex();
   //update vault history
   const vaultTransaction = getTransactionDetail(
+    event.transaction.from,
+    EMPTY_ADDR,
     event.params.vaultId,
     event.params.collateralPaid,
     vault,
@@ -228,6 +239,8 @@ export function handleMintShort(event: MintShort): void {
 
   //update vault history
   const vaultTransaction = getTransactionDetail(
+    event.transaction.from,
+    event.params.sender,
     event.params.vaultId,
     event.params.amount,
     vault,
@@ -298,6 +311,8 @@ export function handleWithdrawCollateral(event: WithdrawCollateral): void {
 
   //update vault history
   const vaultTransaction = getTransactionDetail(
+    event.transaction.from,
+    event.params.sender,
     event.params.vaultId,
     event.params.amount,
     vault,
@@ -389,6 +404,8 @@ function getDayStatSnapshot(timestamp: BigInt): DayStatSnapshot {
 }
 
 function getTransactionDetail(
+  from: Address,
+  sender: Address,
   vaultId: BigInt,
   amount: BigInt,
   vault: Vault,
@@ -403,6 +420,8 @@ function getTransactionDetail(
   vaultHistory.vaultId = vaultId;
   vaultHistory.txid = transactionHash;
   vaultHistory.timestamp = timestamp;
+  vaultHistory.from = from;
+  vaultHistory.sender = sender;
 
   if (action == "DEPOSIT_COLLAT" || action == "WITHDRAW_COLLAT") {
     vaultHistory.ethCollateralAmount = amount;

--- a/packages/subgraph/src/controller.ts
+++ b/packages/subgraph/src/controller.ts
@@ -37,7 +37,12 @@ import {
 } from "../generated/schema";
 import { loadOrCreateAccount } from "./util";
 
-import { BIGINT_ONE, BIGINT_ZERO, SHORT_HELPER_ADDR } from "./constants";
+import {
+  BIGINT_ONE,
+  BIGINT_ZERO,
+  SHORT_HELPER_ADDR,
+  EMPTY_ADDR,
+} from "./constants";
 
 // Note: If a handler doesn't require existing field values, it is faster
 // _not_ to load the entity from the store. Instead, create it fresh with
@@ -181,7 +186,7 @@ export function handleLiquidate(event: Liquidate): void {
   //update vault history
   const vaultTransaction = getTransactionDetail(
     event.transaction.from,
-    event.transaction.from,
+    EMPTY_ADDR,
     event.params.vaultId,
     event.params.collateralPaid,
     vault,
@@ -399,8 +404,8 @@ function getDayStatSnapshot(timestamp: BigInt): DayStatSnapshot {
 }
 
 function getTransactionDetail(
-  from: Address,
-  sender: Address,
+  from: Bytes,
+  sender: Bytes,
   vaultId: BigInt,
   amount: BigInt,
   vault: Vault,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10107,10 +10107,30 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv-cli@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-cli/-/dotenv-cli-5.1.0.tgz#0d2942b089082da0157f9b26bd6c5c4dd51ef48e"
+  integrity sha512-NoEZAlKo9WVrG0b3i9mBxdD6INdDuGqdgR74t68t8084QcI077/1MnPerRW1odl+9uULhcdnQp2U0pYVppKHOA==
+  dependencies:
+    cross-spawn "^7.0.3"
+    dotenv "^16.0.0"
+    dotenv-expand "^8.0.1"
+    minimist "^1.2.5"
+
+dotenv-expand@^8.0.1:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-8.0.3.tgz#29016757455bcc748469c83a19b36aaf2b83dd6e"
+  integrity sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==
+
 dotenv@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
 
 dotenv@^8.0.0:
   version "8.6.0"


### PR DESCRIPTION
# Task:

## Description

1. add transaction.from and params.sender to vaultHistory for tx history query, cuz current useVaultHistory only supports query by vault id
2. This is the prerequisites of issue #26 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested
Tested with https://api.thegraph.com/subgraphs/name/yichiehliu/squeeth

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
