### PR TITLE
Long/Close didn't load a user's oSQTH balance

### DIFF
--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -633,11 +633,14 @@ const CloseLong: React.FC<BuyProps> = () => {
   const resetEthTradeAmount = useResetAtom(ethTradeAmountAtom)
   const resetSqthTradeAmount = useResetAtom(sqthTradeAmountAtom)
 
+  console.log({ longSqthBal: longSqthBal.toString(), ethTradeAmount })
+
   useEffect(() => {
     //if it's insufficient amount them set it to it's maximum
     if (longSqthBal.lt(amount)) {
       setSqthTradeAmount(longSqthBal.toString())
       getSellQuoteForETH(longSqthBal).then((val) => {
+        console.log({ amountIn: val.amountIn.toString() })
         setEthTradeAmount(val.amountIn.toString())
         setConfirmedAmount(val.amountIn.toFixed(6).toString())
       })
@@ -720,6 +723,7 @@ const CloseLong: React.FC<BuyProps> = () => {
       setSqthTradeAmount(value)
       getSellQuote(new BigNumber(value), slippageAmount).then((val) => {
         if (value !== '0') setConfirmedAmount(Number(value).toFixed(6))
+        console.log({ amountIn2: val.amountOut.toString() })
         setEthTradeAmount(val.amountOut.toString())
         setInputQuoteLoading(false)
       })

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -633,14 +633,11 @@ const CloseLong: React.FC<BuyProps> = () => {
   const resetEthTradeAmount = useResetAtom(ethTradeAmountAtom)
   const resetSqthTradeAmount = useResetAtom(sqthTradeAmountAtom)
 
-  console.log({ longSqthBal: longSqthBal.toString(), ethTradeAmount })
-
   useEffect(() => {
     //if it's insufficient amount them set it to it's maximum
     if (longSqthBal.lt(amount)) {
       setSqthTradeAmount(longSqthBal.toString())
       getSellQuoteForETH(longSqthBal).then((val) => {
-        console.log({ amountIn: val.amountIn.toString() })
         setEthTradeAmount(val.amountIn.toString())
         setConfirmedAmount(val.amountIn.toFixed(6).toString())
       })
@@ -723,7 +720,6 @@ const CloseLong: React.FC<BuyProps> = () => {
       setSqthTradeAmount(value)
       getSellQuote(new BigNumber(value), slippageAmount).then((val) => {
         if (value !== '0') setConfirmedAmount(Number(value).toFixed(6))
-        console.log({ amountIn2: val.amountOut.toString() })
         setEthTradeAmount(val.amountOut.toString())
         setInputQuoteLoading(false)
       })

--- a/packages/frontend/src/hooks/contracts/useTokenBalance.ts
+++ b/packages/frontend/src/hooks/contracts/useTokenBalance.ts
@@ -35,10 +35,12 @@ export const useTokenBalance = (token: string, refetchIntervalSec = 30, decimals
     () => updateBalance(token, connected, contract, address, decimals),
     {
       enabled: Boolean(token) && Boolean(connected) && Boolean(contract),
-      refetchInterval: refetchIntervalSec * 15000,
+      refetchInterval: refetchIntervalSec * 1000,
       staleTime: 15000,
     },
   )
+
+  console.log({ osqueethBal: balanceQuery.data?.toString() }, 'in useTokenBalance')
 
   return { value: balanceQuery.data ?? new BigNumber(0), loading: !balanceQuery.data }
 }

--- a/packages/frontend/src/hooks/contracts/useTokenBalance.ts
+++ b/packages/frontend/src/hooks/contracts/useTokenBalance.ts
@@ -8,9 +8,15 @@ import erc20Abi from '../../abis/erc20.json'
 import { toTokenAmount } from '@utils/calculations'
 // import { useIntervalAsync } from '@hooks/useIntervalAsync'
 import { addressAtom, connectedWalletAtom, web3Atom } from 'src/state/wallet/atoms'
-
+interface TokenQueryKeyParams {
+  token: string
+  connected: boolean
+  address: string | null
+  decimals: number
+  refetchIntervalSec: number
+}
 const tokenBalanceQueryKeys = {
-  userTokenBalance: (token: string) => ['userTokenBalance', token],
+  userTokenBalance: (params: TokenQueryKeyParams) => ['userTokenBalance', params],
 }
 /**
  * get token balance.
@@ -31,7 +37,7 @@ export const useTokenBalance = (token: string, refetchIntervalSec = 30, decimals
   }, [web3, token])
 
   const balanceQuery = useQuery(
-    tokenBalanceQueryKeys.userTokenBalance(token),
+    tokenBalanceQueryKeys.userTokenBalance({ address, connected, decimals, refetchIntervalSec, token }),
     () => updateBalance(token, connected, contract, address, decimals),
     {
       enabled: Boolean(token) && Boolean(connected) && Boolean(contract),

--- a/packages/frontend/src/hooks/contracts/useTokenBalance.ts
+++ b/packages/frontend/src/hooks/contracts/useTokenBalance.ts
@@ -41,12 +41,10 @@ export const useTokenBalance = (token: string, refetchIntervalSec = 30, decimals
     () => updateBalance(token, connected, contract, address, decimals),
     {
       enabled: Boolean(token) && Boolean(connected) && Boolean(contract),
-      refetchInterval: refetchIntervalSec * 1000,
+      refetchInterval: refetchIntervalSec * 15000,
     },
   )
-
   console.log({ osqueethBal: balanceQuery.data?.toString() }, 'in useTokenBalance')
-
   return { value: balanceQuery.data ?? new BigNumber(0), loading: !balanceQuery.data }
 }
 

--- a/packages/frontend/src/hooks/contracts/useTokenBalance.ts
+++ b/packages/frontend/src/hooks/contracts/useTokenBalance.ts
@@ -44,7 +44,7 @@ export const useTokenBalance = (token: string, refetchIntervalSec = 30, decimals
       refetchInterval: refetchIntervalSec * 15000,
     },
   )
-  console.log({ osqueethBal: balanceQuery.data?.toString() }, 'in useTokenBalance')
+
   return { value: balanceQuery.data ?? new BigNumber(0), loading: !balanceQuery.data }
 }
 

--- a/packages/frontend/src/hooks/contracts/useTokenBalance.ts
+++ b/packages/frontend/src/hooks/contracts/useTokenBalance.ts
@@ -42,7 +42,6 @@ export const useTokenBalance = (token: string, refetchIntervalSec = 30, decimals
     {
       enabled: Boolean(token) && Boolean(connected) && Boolean(contract),
       refetchInterval: refetchIntervalSec * 1000,
-      staleTime: 15000,
     },
   )
 

--- a/packages/frontend/src/state/positions/hooks.ts
+++ b/packages/frontend/src/state/positions/hooks.ts
@@ -192,10 +192,6 @@ export const useLongSqthBal = () => {
     return mintedDebt.gt(0) ? oSqueethBal.minus(mintedDebt) : oSqueethBal
   }, [oSqueethBal?.toString(), mintedDebt.toString()])
 
-  console.log(
-    { oSqueeth, oSqueethBal: oSqueethBal.toString(), mintedDebt: mintedDebt.toString() },
-    'in useLongSqthBall',
-  )
   return longSqthBal
 }
 

--- a/packages/frontend/src/state/positions/hooks.ts
+++ b/packages/frontend/src/state/positions/hooks.ts
@@ -191,6 +191,11 @@ export const useLongSqthBal = () => {
   const longSqthBal = useMemo(() => {
     return mintedDebt.gt(0) ? oSqueethBal.minus(mintedDebt) : oSqueethBal
   }, [oSqueethBal?.toString(), mintedDebt.toString()])
+
+  console.log(
+    { oSqueeth, oSqueethBal: oSqueethBal.toString(), mintedDebt: mintedDebt.toString() },
+    'in useLongSqthBall',
+  )
   return longSqthBal
 }
 


### PR DESCRIPTION
# Task:

## Description

- Update tokenBalanceQueryKeys to include relevant variables ensuring osqth bal is always updated.

Fixes # (issue)
#220 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

1.	Open a long position buy buying squeeth from long/open.
2.	close the page.
3.	Re-open the page and try to close oSQTH position by selling from long/close on the trade page.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
