### PR TITLE
Show concise description when error happens on PnL calc

### DIFF
--- a/packages/frontend/src/components/PositionCard.tsx
+++ b/packages/frontend/src/components/PositionCard.tsx
@@ -5,7 +5,7 @@ import InfoIcon from '@material-ui/icons/InfoOutlined'
 import BigNumber from 'bignumber.js'
 import clsx from 'clsx'
 import Link from 'next/link'
-import React, { memo, useState } from 'react'
+import React, { memo, useMemo, useState } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
 
 import { Tooltips } from '@constants/enums'
@@ -306,6 +306,10 @@ const PositionCard: React.FC = () => {
     }
   }, [longUnrealizedPNL.loading, positionType, shortUnrealizedPNL.loading])
 
+  const pnlError = useMemo(() => {
+    return positionType === PositionType.SHORT && shortUnrealizedPNL.error
+  }, [shortUnrealizedPNL.error, positionType])
+
   return (
     <div className={clsx(classes.container, classes.posBg)}>
       {!fullyLiquidated ? (
@@ -382,7 +386,11 @@ const PositionCard: React.FC = () => {
                     </Tooltip>
                   </div>
                   <div className={classes.pnl} id="unrealized-pnl-value">
-                    {!pnlLoading ? (
+                    {pnlError ? (
+                      pnlError
+                    ) : pnlLoading ? (
+                      'Loading'
+                    ) : (
                       <>
                         <Typography
                           className={pnlClass(positionType, longGain, shortGain, classes)}
@@ -405,8 +413,6 @@ const PositionCard: React.FC = () => {
                           {getPositionBasedValue(`(${longGain.toFixed(2)}%)`, `(${shortGain.toFixed(2)}%)`, null, ' ')}
                         </Typography>
                       </>
-                    ) : (
-                      'Loading'
                     )}
                   </div>
                 </div>

--- a/packages/frontend/src/lib/pnl.ts
+++ b/packages/frontend/src/lib/pnl.ts
@@ -9,6 +9,7 @@ import { toTokenAmount } from '@utils/calculations'
 import { getHistoricEthPrice } from '@hooks/useETHPrice'
 import { getETHWithinOneDayPrices } from '@utils/ethPriceCharts'
 import { Action } from '../../types/global_apollo'
+import floatifyBigNums from '@utils/floatifyBigNums'
 
 type ShortPnLParams = {
   wethAmount: BigNumber
@@ -85,7 +86,11 @@ export async function calcETHCollateralPnl(
       }, Promise.resolve({ deposits: BIG_ZERO, withdrawals: BIG_ZERO, priceError: false }))
     : { deposits: BIG_ZERO, withdrawals: BIG_ZERO, priceError: true }
 
-  return !priceError ? currentVaultEthBalance.times(uniswapEthPrice).minus(deposits.minus(withdrawals)) : BIG_ZERO
+  if (priceError) {
+    throw new Error('Collateral PnL Error')
+  }
+
+  return currentVaultEthBalance.times(uniswapEthPrice).minus(deposits.minus(withdrawals))
 }
 /**
  * getRelevantSwaps - gets the swaps that constitute the users current position

--- a/packages/frontend/src/state/pnl/atoms.ts
+++ b/packages/frontend/src/state/pnl/atoms.ts
@@ -2,7 +2,7 @@ import { atom } from 'jotai'
 import { BIG_ZERO } from '@constants/index'
 
 export const ethCollateralPnlAtom = atom(BIG_ZERO)
-export const shortUnrealizedPNLAtom = atom({ usd: BIG_ZERO, eth: BIG_ZERO, loading: true })
+export const shortUnrealizedPNLAtom = atom({ usd: BIG_ZERO, eth: BIG_ZERO, loading: true, error: '' })
 export const longUnrealizedPNLAtom = atom({ usd: BIG_ZERO, eth: BIG_ZERO, loading: true })
 export const buyQuoteAtom = atom(BIG_ZERO)
 export const sellQuoteAtom = atom({


### PR DESCRIPTION
# Task:

## Description
If an error occurs in calculating the PnL of the short position (ex: twelve data fetching error), it showed infinite loading which confuses the user. This PR is for showing a proper error message when something goes long.
![image](https://user-images.githubusercontent.com/59410529/165838579-f11d4a00-0b30-4d46-b32f-3e2a11ea634c.png)


Fixes # (issue)
https://github.com/opynfinance/squeeth-monorepo/issues/282

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
