### PR TITLE
Fix max removable collateral amount in vault page

### DIFF
--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -803,7 +803,11 @@ const Component: React.FC = () => {
                         onClick={() =>
                           collateralBN.isPositive()
                             ? updateCollateral(toTokenAmount(balance ?? BIG_ZERO, 18).toString())
-                            : updateCollateral(vault ? vault?.collateralAmount.negated().toString() : collateral)
+                            : updateCollateral(
+                                vault
+                                  ? vault?.collateralAmount.minus(MIN_COLLATERAL_AMOUNT).negated().toString()
+                                  : collateral,
+                              )
                         }
                         variant="text"
                       >
@@ -813,7 +817,7 @@ const Component: React.FC = () => {
 
                     <NumberInput
                       id="collat-amount-input"
-                      min={vault?.collateralAmount.negated().toString()}
+                      min={vault?.collateralAmount.minus(MIN_COLLATERAL_AMOUNT).negated().toString()}
                       step={0.1}
                       placeholder="Collateral"
                       onChange={(v) => updateCollateral(v)}


### PR DESCRIPTION
# Task: Max removable collateral amount is not valid when click on max

## Description
Fix max removable collateral amount when clicking max button in adjust collateral section of vault page

Fixes #309 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
