### PR TITLE
Fe/fix partial close input

### DIFF
--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -731,7 +731,16 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
   }, [vaultId, shortHelper, firstValidVault, shortVaults])
 
   useAppEffect(() => {
-    if (shortVaults.length) {
+
+    if (amount.isEqualTo(0)) {
+      setExistingCollat(new BigNumber(0))
+      setNeededCollat(new BigNumber(0))
+      setWithdrawCollat(new BigNumber(0))
+    }
+  }, [amount])
+
+  useAppEffect(() => {
+    if (shortVaults.length && !amount.isEqualTo(0)) {
       const _collat: BigNumber = vault?.collateralAmount ?? new BigNumber(0)
       setExistingCollat(_collat)
       const restOfShort = new BigNumber(vault?.shortAmount ?? new BigNumber(0)).minus(amount)

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -986,6 +986,8 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
               onChange={(event: React.ChangeEvent<{ value: unknown }>) => {
                 if (event.target.value === CloseType.FULL) {
                   setShortCloseMax()
+                } else {
+                  setSqthTradeAmount('0')
                 }
                 setCollatPercent(200)
                 return setCloseType(event.target.value as CloseType)


### PR DESCRIPTION
# Task:

## Description

-  When select partial close, the input should be reset to zero to avoid having CR changes with max amount but on partial close

Fixes #275  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Added video recordings if it is a UI change

https://user-images.githubusercontent.com/26922518/166415743-e0335a14-c995-4348-b271-b11d984331ff.mov

