### PR TITLE
Fix buy params sent to a trade seems not to be loaded

### DIFF
--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -292,11 +292,11 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
 
   useAppEffect(() => {
     if (open && tradeType === TradeType.LONG) {
-      getBuyQuoteForETH(new BigNumber(sqthTradeAmount), slippageAmount).then((val) => {
+      getBuyQuoteForETH(new BigNumber(ethTradeAmount), slippageAmount).then((val) => {
         setQuote(val)
       })
     }
-  }, [slippageAmount, sqthTradeAmount, getBuyQuoteForETH, open, setQuote, tradeType])
+  }, [slippageAmount, ethTradeAmount, getBuyQuoteForETH, open, setQuote, tradeType])
 
   const handleEthChange = useAppCallback(
     (value: string) => {

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -654,7 +654,7 @@ const CloseLong: React.FC<BuyProps> = () => {
       setSqthTradeAmount(squeethAmount.toString())
       getSellQuote(squeethAmount).then((val) => {
         setEthTradeAmount(val.amountOut.toString())
-        setConfirmedAmount(val.amountOut.toFixed(6).toString())
+        setConfirmedAmount(squeethAmount.toFixed(6))
       })
     }
   }, [squeethAmount, amount, getSellQuote, setConfirmedAmount, setEthTradeAmount, setSqthTradeAmount])

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -652,12 +652,12 @@ const CloseLong: React.FC<BuyProps> = () => {
     //if it's insufficient amount them set it to it's maximum
     if (squeethAmount.lt(amount)) {
       setSqthTradeAmount(squeethAmount.toString())
-      getSellQuoteForETH(squeethAmount).then((val) => {
-        setEthTradeAmount(val.amountIn.toString())
-        setConfirmedAmount(val.amountIn.toFixed(6).toString())
+      getSellQuote(squeethAmount).then((val) => {
+        setEthTradeAmount(val.amountOut.toString())
+        setConfirmedAmount(val.amountOut.toFixed(6).toString())
       })
     }
-  }, [squeethAmount, amount, getSellQuoteForETH, setConfirmedAmount, setEthTradeAmount, setSqthTradeAmount])
+  }, [squeethAmount, amount, getSellQuote, setConfirmedAmount, setEthTradeAmount, setSqthTradeAmount])
 
   // let openError: string | undefined
   let closeError: string | undefined

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -727,7 +727,7 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
   useAppEffect(() => {
     if (!vaultId) return
 
-    setIsVaultApproved(shortVaults[firstValidVault].operator?.toLowerCase() === shortHelper?.toLowerCase())
+    setIsVaultApproved(shortVaults[firstValidVault]?.operator?.toLowerCase() === shortHelper?.toLowerCase())
   }, [vaultId, shortHelper, firstValidVault, shortVaults])
 
   useAppEffect(() => {


### PR DESCRIPTION
Task:

## Description

- Fixes wrong getBuyQuote for eth params which causes error with the open long transaction.
- Replaces getSellQuoteForETH with getSellQuote which may also be causing a similar error on long close transactions.

Fixes # (issue)
#368 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
