### PR TITLE
Add historical price to async request 

### DIFF
--- a/packages/frontend/pages/api/historicalprice.ts
+++ b/packages/frontend/pages/api/historicalprice.ts
@@ -1,0 +1,78 @@
+import { format } from 'date-fns'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+const TWELVE_DATA_API = 'https://api.twelvedata.com'
+
+/**
+ * Get Historical price using https://twelvedata.com/docs#complex-data complex data API
+ */
+const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { timestamps, interval, pair, tz } = req.query
+
+  if (timestamps instanceof Array) {
+    res.status(400).json({ status: 'error', message: 'Array params is not supported' })
+    return
+  }
+
+  const timestampArr = timestamps.split(',')
+  const methods = generateMethodData(timestampArr, interval)
+
+  const resp = await fetch(`${TWELVE_DATA_API}/complex_data?apikey=${process.env.NEXT_PUBLIC_TWELVEDATA_APIKEY}`, {
+    method: 'POST',
+    body: JSON.stringify({
+      symbols: [pair],
+      timezone: tz,
+      intervals: [interval],
+      outputsize: 1,
+      methods,
+    }),
+  })
+
+  const respJson = await resp.json()
+  // return res.status(200).json(respJson)
+
+  const [current, ...rest] = respJson.data as Array<any>
+
+  // complex_data API returns current price, historical price for each timestamp
+  // So rest value will be in the format [1st historical price, current price, 2nd historical price, current price, ...]
+  // So filtering historical price
+  const priceData = rest.filter((_, index) => index % 2 === 0)
+
+  if (timestampArr.length !== priceData.length) {
+    res.status(400).json({ status: 'error', message: 'Timestamps size and price data length mis match' })
+    return
+  }
+
+  const resultJson = timestampArr.reduce((acc, timestamp, index) => {
+    const priceResp = priceData[index]
+    if (priceResp.status === 'error') {
+      acc[timestamp] = current.values[0].close
+    } else {
+      acc[timestamp] = priceResp.values[0].close
+    }
+    return acc
+  }, {} as { [key: string]: string })
+
+  res.status(200).json(resultJson)
+}
+
+// Generate method param from timestamps that's needed to sent to twelvedata API
+const generateMethodData = (timestampArr: string[], interval: string | string[]) => {
+  const methods = []
+
+  for (const timestamp of timestampArr) {
+    const date = format(new Date(Number(timestamp)).setUTCSeconds(0, 0), 'yyyy-MM-dd HH:mm:ss')
+
+    const params = {
+      interval,
+      start_date: date,
+      end_date: date,
+      symbols: ['ETH/USD'],
+    }
+    methods.push('time_series', params)
+  }
+
+  return methods
+}
+
+export default handleRequest

--- a/packages/frontend/pages/api/twelvedata.ts
+++ b/packages/frontend/pages/api/twelvedata.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const TWELVE_DATA_API = 'https://api.twelvedata.com'
@@ -14,10 +15,11 @@ const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
     return
   }
 
-  const jsonResponse = await (
-    await fetch(`${TWELVE_DATA_API}/${path}?${queryString}&apikey=${process.env.NEXT_PUBLIC_TWELVEDATA_APIKEY}`)
-  ).json()
-  res.status(200).json(jsonResponse)
+  const jsonResponse = await axios.get(
+    `${TWELVE_DATA_API}/${path}?${queryString}&apikey=${process.env.NEXT_PUBLIC_TWELVEDATA_APIKEY}`,
+  )
+
+  res.status(200).json(jsonResponse.data)
 }
 
 export default handleRequest

--- a/packages/frontend/src/hooks/useETHPrice.ts
+++ b/packages/frontend/src/hooks/useETHPrice.ts
@@ -55,3 +55,22 @@ export const getHistoricEthPrice = async (dateString: string): Promise<BigNumber
 
   return new BigNumber(Number(response.values[0].close))
 }
+
+export const getHistoricEthPrices = async (timestamps: number[]) => {
+  const timestampStr = timestamps.join(',')
+  const pair = 'ETH/USD'
+
+  const response = await (
+    await fetch(
+      `/api/historicalprice?timestamps=${timestampStr}&pair=${pair}&interval=1min&timezone=${
+        Intl.DateTimeFormat().resolvedOptions().timeZone
+      }`,
+    )
+  ).json()
+
+  if (response.status === 'error') {
+    throw new Error(response.message)
+  }
+
+  return response
+}

--- a/packages/frontend/src/lib/pnl.ts
+++ b/packages/frontend/src/lib/pnl.ts
@@ -6,7 +6,7 @@ import { BIG_ZERO, TWELVEDATA_NO_PRICEDATA_DURATION } from '../constants/'
 import { swaps_swaps } from '../queries/uniswap/__generated__/swaps'
 import { VaultHistory_vaultHistories } from '../queries/squeeth/__generated__/VaultHistory'
 import { toTokenAmount } from '@utils/calculations'
-import { getHistoricEthPrice } from '@hooks/useETHPrice'
+import { getHistoricEthPrice, getHistoricEthPrices } from '@hooks/useETHPrice'
 import { getETHWithinOneDayPrices } from '@utils/ethPriceCharts'
 import { Action } from '../../types/global_apollo'
 
@@ -63,27 +63,27 @@ export async function calcETHCollateralPnl(
   uniswapEthPrice: BigNumber,
   currentVaultEthBalance: BigNumber,
 ) {
-  const { deposits, withdrawals, priceError } = data?.length
-    ? await data?.reduce(async (prevPromise, vaultHistory: VaultHistory_vaultHistories) => {
-        const acc = await prevPromise
+  const vaultHistories = await getVaultHistoriesWithEthPrice(data || [])
+  const { deposits, withdrawals, priceError } = vaultHistories.reduce(
+    (acc, vaultHistory) => {
+      const ethPriceAtTimeOfAction = vaultHistory.ethPrice
 
-        const ethPriceAtTimeOfAction = await getEthPriceAtTransactionTime(vaultHistory.timestamp)
-
-        if (ethPriceAtTimeOfAction?.isZero()) {
-          acc.priceError = true
-        }
-        if (vaultHistory.action === Action.DEPOSIT_COLLAT) {
-          acc.deposits = acc.deposits.plus(
-            new BigNumber(toTokenAmount(vaultHistory.ethCollateralAmount, 18)).times(ethPriceAtTimeOfAction),
-          )
-        } else if (vaultHistory.action === Action.WITHDRAW_COLLAT) {
-          acc.withdrawals = acc.withdrawals.plus(
-            new BigNumber(toTokenAmount(vaultHistory.ethCollateralAmount, 18)).times(ethPriceAtTimeOfAction),
-          )
-        }
-        return acc
-      }, Promise.resolve({ deposits: BIG_ZERO, withdrawals: BIG_ZERO, priceError: false }))
-    : { deposits: BIG_ZERO, withdrawals: BIG_ZERO, priceError: true }
+      if (ethPriceAtTimeOfAction?.isZero()) {
+        acc.priceError = true
+      }
+      if (vaultHistory.action === Action.DEPOSIT_COLLAT) {
+        acc.deposits = acc.deposits.plus(
+          new BigNumber(toTokenAmount(vaultHistory.ethCollateralAmount, 18)).times(ethPriceAtTimeOfAction),
+        )
+      } else if (vaultHistory.action === Action.WITHDRAW_COLLAT) {
+        acc.withdrawals = acc.withdrawals.plus(
+          new BigNumber(toTokenAmount(vaultHistory.ethCollateralAmount, 18)).times(ethPriceAtTimeOfAction),
+        )
+      }
+      return acc
+    },
+    { deposits: BIG_ZERO, withdrawals: BIG_ZERO, priceError: false },
+  )
 
   return !priceError ? currentVaultEthBalance.times(uniswapEthPrice).minus(deposits.minus(withdrawals)) : BIG_ZERO
 }
@@ -113,6 +113,38 @@ const getRelevantSwaps = (squeethAmount: BigNumber, swaps: swaps_swaps[], isWeth
   return relevantSwaps
 }
 
+const getSwapsWithEthPrice = async (swaps: swaps_swaps[]) => {
+  const timestamps = swaps.map((s) => Number(s.timestamp) * 1000)
+
+  // Don't fetch if already fetched
+  const ethPriceMap = await queryClient.fetchQuery(timestamps, () => getHistoricEthPrices(timestamps), {
+    staleTime: Infinity,
+  })
+
+  const swapsWithEthPrice = swaps.map((s) => ({
+    ...s,
+    ethPrice: new BigNumber(ethPriceMap[Number(s.timestamp) * 1000]),
+  }))
+
+  return swapsWithEthPrice
+}
+
+const getVaultHistoriesWithEthPrice = async (vaultHistories: VaultHistory_vaultHistories[]) => {
+  const timestamps = vaultHistories.map((v) => Number(v.timestamp) * 1000)
+
+  // Don't fetch if already fetched
+  const ethPriceMap = await queryClient.fetchQuery(timestamps, () => getHistoricEthPrices(timestamps), {
+    staleTime: Infinity,
+  })
+
+  const historyWithEthPrice = vaultHistories.map((v) => ({
+    ...v,
+    ethPrice: new BigNumber(ethPriceMap[Number(v.timestamp) * 1000]),
+  }))
+
+  return historyWithEthPrice
+}
+
 export async function calcDollarShortUnrealizedpnl(
   swaps: swaps_swaps[],
   isWethToken0: boolean,
@@ -122,21 +154,24 @@ export async function calcDollarShortUnrealizedpnl(
   ethCollateralPnl: BigNumber,
 ) {
   const relevantSwaps = getRelevantSwaps(squeethAmount, swaps, isWethToken0)
+  const relevantSwapsWithEthPrice = await getSwapsWithEthPrice(relevantSwaps)
 
-  const { totalWethInUSD, priceError } = await relevantSwaps.reduce(async (prevPromise, swap: any, index) => {
-    const acc = await prevPromise
-    const wethAmt = new BigNumber(isWethToken0 ? swap.amount0 : swap.amount1)
+  const { totalWethInUSD, priceError } = relevantSwapsWithEthPrice.reduce(
+    (acc, swap, index) => {
+      const wethAmt = new BigNumber(isWethToken0 ? swap.amount0 : swap.amount1)
 
-    const ethPriceWhenOpened = await getEthPriceAtTransactionTime(swap.timestamp)
+      const ethPriceWhenOpened = swap.ethPrice
 
-    if (ethPriceWhenOpened?.isZero()) {
-      acc.priceError = true
-    }
+      if (ethPriceWhenOpened?.isZero()) {
+        acc.priceError = true
+      }
 
-    acc.totalWethInUSD = acc.totalWethInUSD.plus(wethAmt.negated().times(ethPriceWhenOpened))
+      acc.totalWethInUSD = acc.totalWethInUSD.plus(wethAmt.negated().times(ethPriceWhenOpened))
 
-    return acc
-  }, Promise.resolve({ totalWethInUSD: BIG_ZERO, priceError: false }))
+      return acc
+    },
+    { totalWethInUSD: BIG_ZERO, priceError: false },
+  )
 
   const usd = totalWethInUSD.minus(buyQuote.times(uniswapEthPrice)).plus(ethCollateralPnl)
 
@@ -159,21 +194,24 @@ export async function calcDollarLongUnrealizedpnl(
   squeethAmount: BigNumber,
 ) {
   const relevantSwaps = getRelevantSwaps(squeethAmount, swaps, isWethToken0, true)
+  const relevantSwapsWithEthPrice = await getSwapsWithEthPrice(relevantSwaps)
 
-  const { totalUSDWethAmount, priceError } = await relevantSwaps.reduce(async (prevPromise, swap: any) => {
-    const acc = await prevPromise
-    const wethAmt = new BigNumber(isWethToken0 ? swap.amount0 : swap.amount1)
+  const { totalUSDWethAmount, priceError } = relevantSwapsWithEthPrice.reduce(
+    (acc, swap) => {
+      const wethAmt = new BigNumber(isWethToken0 ? swap.amount0 : swap.amount1)
 
-    const ethPriceWhenOpened = await getEthPriceAtTransactionTime(swap.timestamp)
+      const ethPriceWhenOpened = swap.ethPrice
 
-    if (ethPriceWhenOpened?.isZero()) {
-      acc.priceError = true
-    }
+      if (ethPriceWhenOpened?.isZero()) {
+        acc.priceError = true
+      }
 
-    acc.totalUSDWethAmount = acc.totalUSDWethAmount.plus(wethAmt.times(ethPriceWhenOpened ?? BIG_ZERO))
+      acc.totalUSDWethAmount = acc.totalUSDWethAmount.plus(wethAmt.times(ethPriceWhenOpened ?? BIG_ZERO))
 
-    return acc
-  }, Promise.resolve({ totalUSDWethAmount: BIG_ZERO, priceError: false }))
+      return acc
+    },
+    { totalUSDWethAmount: BIG_ZERO, priceError: false },
+  )
 
   const usdValue = !priceError ? sellQuote.amountOut.times(uniswapEthPrice).minus(totalUSDWethAmount) : BIG_ZERO
   return {
@@ -187,6 +225,9 @@ const historicPriceQueryKeys = {
   historicPrice: (timestamp: string) => [`userPrice_${timestamp}`],
 }
 
+/**
+ * @deprecated
+ */
 async function getEthPriceAtTransactionTime(timestamp: string) {
   try {
     const timeInMilliseconds = new Date(Number(timestamp) * 1000).setUTCSeconds(0, 0)


### PR DESCRIPTION
# Task:
Fix unrealised PnL loading very slowly

## Description
- ETH historical price is currently fetched sequentially
- It now uses complex_data API which fetches data parallelly for us and gives in single result (It will still cost API credits. ie: If we request the price for 5 timestamps, it will still count as 5 APIs)

Fixes #422 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
