### PR TITLE
Fix vault data not showing for non user vaults

### DIFF
--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -68,6 +68,7 @@ import {
 } from 'src/state/positions/hooks'
 import { useVaultData } from '@hooks/useVaultData'
 import { useVaultManager } from '@hooks/contracts/useVaultManager'
+import useVault from '@hooks/useVault'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -339,8 +340,9 @@ const Component: React.FC = () => {
   const [txLoading, setTxLoading] = useState(false)
   const [uniTokenToDeposit, setUniTokenToDeposit] = useState(0)
 
-  const { validVault: vault, isVaultLoading } = useFirstValidVault()
-  const { existingCollatPercent, existingLiqPrice } = useVaultData(vault)
+  // const { validVault: vault, isVaultLoading } = useFirstValidVault()
+  const { vault, loading: isVaultLoading } = useVault(Number(vid))
+  const { existingCollatPercent, existingLiqPrice } = useVaultData(vault as any)
   const { updateVault } = useVaultManager()
   const [collatPercent, setCollatPercent] = useAtom(collatPercentAtom)
 
@@ -815,10 +817,10 @@ const Component: React.FC = () => {
                           collateralBN.isPositive()
                             ? updateCollateral(toTokenAmount(balance ?? BIG_ZERO, 18).toString())
                             : updateCollateral(
-                                vault
-                                  ? vault?.collateralAmount.minus(MIN_COLLATERAL_AMOUNT).negated().toString()
-                                  : collateral,
-                              )
+                              vault
+                                ? vault?.collateralAmount.minus(MIN_COLLATERAL_AMOUNT).negated().toString()
+                                : collateral,
+                            )
                         }
                         variant="text"
                       >
@@ -938,8 +940,8 @@ const Component: React.FC = () => {
                           shortAmountBN.isPositive()
                             ? updateShort(maxToMint.toString())
                             : vault?.shortAmount.isGreaterThan(oSqueethBal)
-                            ? updateShort(oSqueethBal.negated().toString())
-                            : updateShort(vault?.shortAmount ? vault?.shortAmount.negated().toString() : '0')
+                              ? updateShort(oSqueethBal.negated().toString())
+                              : updateShort(vault?.shortAmount ? vault?.shortAmount.negated().toString() : '0')
                         }
                         variant="text"
                       >
@@ -962,8 +964,8 @@ const Component: React.FC = () => {
                             Balance{' '}
                             <span id="vault-debt-input-osqth-balance">
                               {oSqueethBal?.isGreaterThan(0) &&
-                              positionType === PositionType.LONG &&
-                              oSqueethBal.minus(squeethAmount).isGreaterThan(0)
+                                positionType === PositionType.LONG &&
+                                oSqueethBal.minus(squeethAmount).isGreaterThan(0)
                                 ? oSqueethBal.minus(squeethAmount).toFixed(6)
                                 : oSqueethBal.toFixed(6)}
                             </span>{' '}

--- a/packages/frontend/pages/vault/[vid].tsx
+++ b/packages/frontend/pages/vault/[vid].tsx
@@ -340,10 +340,8 @@ const Component: React.FC = () => {
   const [txLoading, setTxLoading] = useState(false)
   const [uniTokenToDeposit, setUniTokenToDeposit] = useState(0)
 
-  // const { validVault: vault, isVaultLoading } = useFirstValidVault()
-  const { vault, loading: isVaultLoading } = useVault(Number(vid))
+  const { vault, loading: isVaultLoading, updateVault } = useVault(Number(vid))
   const { existingCollatPercent, existingLiqPrice } = useVaultData(vault as any)
-  const { updateVault } = useVaultManager()
   const [collatPercent, setCollatPercent] = useAtom(collatPercentAtom)
 
   useEffect(() => {
@@ -468,9 +466,8 @@ const Component: React.FC = () => {
 
     setTxLoading(true)
     try {
-      await depositCollateral(Number(vault.id), collatAmount, () => {
-        updateVault()
-      })
+      await depositCollateral(Number(vault.id), collatAmount)
+      updateVault()
       updateNftCollateral(BIG_ZERO, BIG_ZERO, currentLpNftId)
     } catch (e) {
       console.log(e)
@@ -483,9 +480,8 @@ const Component: React.FC = () => {
 
     setTxLoading(true)
     try {
-      await withdrawCollateral(Number(vault.id), collatAmount.abs(), () => {
-        updateVault()
-      })
+      await withdrawCollateral(Number(vault.id), collatAmount.abs())
+      updateVault()
 
       updateNftCollateral(BIG_ZERO, BIG_ZERO, currentLpNftId)
     } catch (e) {
@@ -499,9 +495,8 @@ const Component: React.FC = () => {
 
     setTxLoading(true)
     try {
-      await openDepositAndMint(Number(vault.id), sAmount, new BigNumber(0), () => {
-        updateVault()
-      })
+      await openDepositAndMint(Number(vault.id), sAmount, new BigNumber(0))
+      updateVault()
       updateNftCollateral(BIG_ZERO, BIG_ZERO, currentLpNftId)
     } catch (e) {
       console.log(e)
@@ -514,9 +509,8 @@ const Component: React.FC = () => {
 
     setTxLoading(true)
     try {
-      await burnAndRedeem(Number(vault.id), sAmount.abs(), new BigNumber(0), () => {
-        updateVault()
-      })
+      await burnAndRedeem(Number(vault.id), sAmount.abs(), new BigNumber(0))
+      updateVault()
       updateNftCollateral(BIG_ZERO, BIG_ZERO, currentLpNftId)
     } catch (e) {
       console.log(e)
@@ -529,9 +523,8 @@ const Component: React.FC = () => {
 
     setTxLoading(true)
     try {
-      await depositUniPositionToken(Number(vault.id), tokenId, () => {
-        updateVault()
-      })
+      await depositUniPositionToken(Number(vault.id), tokenId)
+      updateVault()
       setAction(VaultAction.WITHDRAW_UNI_POSITION)
     } catch (e) {
       console.log(e)
@@ -545,9 +538,8 @@ const Component: React.FC = () => {
     setTxLoading(true)
     setAction(VaultAction.WITHDRAW_UNI_POSITION)
     try {
-      await withdrawUniPositionToken(Number(vault.id), () => {
-        updateVault()
-      })
+      await withdrawUniPositionToken(Number(vault.id))
+      updateVault()
       // reset to default action, shld check if this nft got approved with history
       // cuz now there is no nft selected
       setAction(VaultAction.ADD_COLLATERAL)

--- a/packages/frontend/src/hooks/useVault.ts
+++ b/packages/frontend/src/hooks/useVault.ts
@@ -1,5 +1,5 @@
 import { Vault } from '../types'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useGetVault } from 'src/state/controller/hooks'
 
 const useVault = (vid: number) => {
@@ -14,7 +14,11 @@ const useVault = (vid: number) => {
     })
   }, [getVault, vid])
 
-  return { vault, loading }
+  const updateVault = useCallback(() => {
+    getVault(vid).then((v) => setVault(v ?? undefined))
+  }, [getVault, vid])
+
+  return { vault, loading, updateVault }
 }
 
 export default useVault

--- a/packages/frontend/src/hooks/useVault.ts
+++ b/packages/frontend/src/hooks/useVault.ts
@@ -1,0 +1,20 @@
+import { Vault } from '../types'
+import { useEffect, useState } from 'react'
+import { useGetVault } from 'src/state/controller/hooks'
+
+const useVault = (vid: number) => {
+  const getVault = useGetVault()
+  const [vault, setVault] = useState<Vault>()
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getVault(vid).then((v) => {
+      setVault(v ?? undefined)
+      setLoading(false)
+    })
+  }, [getVault, vid])
+
+  return { vault, loading }
+}
+
+export default useVault


### PR DESCRIPTION
## Description
Instead of using vault id from the query param. UI uses the user's first vault. This behavior is changed in this PR


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested
test https://squeeth.opyn.co/vault/70 and https://continuouscall-git-fix-vault-data-missing-opynfinance.vercel.app/vault/70 to see the difference

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
