### PR TITLE
Fix scroll not working in development

### DIFF
--- a/packages/frontend/styles/globals.css
+++ b/packages/frontend/styles/globals.css
@@ -10,6 +10,7 @@ body {
   height: 100vh;
   background-repeat: no-repeat;
   background-attachment: fixed;
+  overflow: unset !important;
 }
 
 html {


### PR DESCRIPTION
# Task:
https://github.com/opynfinance/squeeth-monorepo/issues/445
While running Next.js on local, overflow hidden is automatically applied to the body. It makes it hard to work on the strategies and positions page.
![image](https://user-images.githubusercontent.com/59410529/167759131-44166ad9-1cab-4408-9b12-2767476204f7.png)

## Description
Unset the overflow style of the body to show scroll always
![image](https://user-images.githubusercontent.com/59410529/167759591-9966d2ad-3f44-43f0-8e69-56a86d316446.png)

Fixes # (issue) https://github.com/opynfinance/squeeth-monorepo/issues/445

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
