### PR TITLE
Add breakeven to long squeeth

### DIFF
--- a/packages/frontend/src/components/Trade/Long/BreakEven.tsx
+++ b/packages/frontend/src/components/Trade/Long/BreakEven.tsx
@@ -23,9 +23,7 @@ const BreakEven: React.FC = () => {
       <TradeInfoItem
         label="ETH move to breakeven"
         value={breakEven.toFixed(3)}
-        tooltip={`To breakeven ETH to needs to move to ${breakEven.toFixed(
-          3,
-        )}% in one day, since current funding is{' '}
+        tooltip={`To breakeven ETH to needs to move to ${breakEven.toFixed(3)}% in one day, since current funding is 
         ${(currentFunding * 100).toFixed(2)}%`}
         unit="%"
         id="open-long-eth-breakdown"

--- a/packages/frontend/src/components/Trade/Long/BreakEven.tsx
+++ b/packages/frontend/src/components/Trade/Long/BreakEven.tsx
@@ -1,0 +1,37 @@
+import useAppMemo from '@hooks/useAppMemo'
+import { getBreakEvenForLongSqueeth, toTokenAmount } from '@utils/calculations'
+import { useAtomValue } from 'jotai'
+import React from 'react'
+import { currentImpliedFundingAtom, indexAtom, markAtom, normFactorAtom } from 'src/state/controller/atoms'
+import TradeInfoItem from '../TradeInfoItem'
+
+const BreakEven: React.FC = () => {
+  const mark = useAtomValue(markAtom)
+  const index = useAtomValue(indexAtom)
+  const days = 1
+  const normFactor = useAtomValue(normFactorAtom)
+  const currentFunding = useAtomValue(currentImpliedFundingAtom)
+
+  const breakEven = useAppMemo(() => {
+    const breakEvenValue = getBreakEvenForLongSqueeth(mark, index, normFactor, days)
+    const ethPrice = toTokenAmount(index, 18).sqrt()
+    return (breakEvenValue / ethPrice.toNumber() - 1) * 100
+  }, [index, mark, normFactor])
+
+  return (
+    <div>
+      <TradeInfoItem
+        label="ETH move to breakeven"
+        value={breakEven.toFixed(3)}
+        tooltip={`To breakeven ETH to needs to move to ${breakEven.toFixed(
+          3,
+        )}% in one day, since current funding is{' '}
+        ${(currentFunding * 100).toFixed(2)}%`}
+        unit="%"
+        id="open-long-eth-breakdown"
+      />
+    </div>
+  )
+}
+
+export default BreakEven

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -47,6 +47,7 @@ import { currentImpliedFundingAtom, dailyHistoricalFundingAtom } from 'src/state
 import useAppEffect from '@hooks/useAppEffect'
 import useAppCallback from '@hooks/useAppCallback'
 import useAppMemo from '@hooks/useAppMemo'
+import BreakEven from './BreakEven'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -538,6 +539,7 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
                   frontUnit="$"
                   id="open-short-eth-down-50%"
                 />
+                <BreakEven />
                 <div style={{ marginTop: '10px' }}>
                   <UniswapData
                     slippage={isNaN(Number(slippageAmount)) ? '0' : slippageAmount.toString()}

--- a/packages/frontend/src/utils/calculations.ts
+++ b/packages/frontend/src/utils/calculations.ts
@@ -2,7 +2,7 @@ import { Percent } from '@uniswap/sdk-core'
 import { Pool } from '@uniswap/v3-sdk'
 import BigNumber from 'bignumber.js'
 
-import { DEFAULT_SLIPPAGE } from '../constants'
+import { BIG_ZERO, DEFAULT_SLIPPAGE, FUNDING_PERIOD } from '../constants'
 import { CollateralStatus } from '../types'
 
 export function toTokenAmount(amount: BigNumber | number | string, decimals: number): BigNumber {
@@ -35,4 +35,24 @@ export function getCollatPercentStatus(collatPercent: number) {
   if (collatPercent < 200) return CollateralStatus.DANGER
   if (collatPercent < 225) return CollateralStatus.RISKY
   return CollateralStatus.SAFE
+}
+
+/**
+ * For the given params it returns breakeven ETH price.
+ *
+ * Calculation is done with the help of https://docs.google.com/spreadsheets/d/1k1Y_WZ4Of9Prsn5hpHX2BXfdPuUg24X_KBrgYvV8Yw4/edit#gid=0
+ */
+export function getBreakEvenForLongSqueeth(
+  markPrice: BigNumber,
+  indexPrice: BigNumber,
+  normFactor: BigNumber,
+  days: number,
+) {
+  const markToIndexRatio = markPrice.div(indexPrice)
+  const indexToMarkRatio = indexPrice.div(markPrice)
+
+  const newNormFactor = normFactor.toNumber() * Math.pow(indexToMarkRatio.toNumber(), days / FUNDING_PERIOD)
+  console.log(newNormFactor, markToIndexRatio.toString(), toTokenAmount(markPrice, 18).toString())
+  const breakEven = Math.sqrt(toTokenAmount(indexPrice, 18).multipliedBy(normFactor).div(newNormFactor).toNumber())
+  return breakEven
 }


### PR DESCRIPTION
# Task:
Add breakeven ETH price in long squeeth

## Description
Here's the calculation for breakeven https://docs.google.com/spreadsheets/d/1k1Y_WZ4Of9Prsn5hpHX2BXfdPuUg24X_KBrgYvV8Yw4/edit#gid=0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Added video recordings if it is a UI change

<img width="374" alt="Screen Shot 2022-05-12 at 8 33 39 am" src="https://user-images.githubusercontent.com/24666922/167958408-bb6fdc76-5846-4419-bb38-639e0ef400db.png">

