### PR TITLE
Fix: using different uniswap pool in flashswapWBurnBuyLong() and flashswapSellLongWMint()

### DIFF
--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -797,10 +797,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                 data.collateralToWithdraw
             );
 
-            IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                _pool,
-                _amountToPay
-            );
+            IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(_pool, _amountToPay);
             IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
                 _caller,
                 data.wPowerPerpAmountToBuy
@@ -832,18 +829,12 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                     );
             }
 
-            IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
-                _pool,
-                _amountToPay
-            );
+            IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(_pool, _amountToPay);
         } else if (
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTIN_WPOWERPERP_ETH
         ) {
-            IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
-                _pool,
-                _amountToPay
-            );
+            IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(_pool, _amountToPay);
 
             if (address(this).balance > 0)
                 IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).deposit{value: address(this).balance}();
@@ -851,10 +842,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTOUT_ETH_WPOWERPERP
         ) {
-            IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                _pool,
-                _amountToPay
-            );
+            IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(_pool, _amountToPay);
             return;
         } else if (
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
@@ -873,10 +861,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                 data.collateralToWithdraw
             );
 
-            IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                _pool,
-                _amountToPay
-            );
+            IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(_pool, _amountToPay);
         } else if (
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
             ControllerHelperDataType.CALLBACK_SOURCE.GENERAL_SWAP

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -3,6 +3,8 @@
 pragma solidity =0.7.6;
 pragma abicoder v2;
 
+import "hardhat/console.sol";
+
 // interface
 import {IWETH9} from "../interfaces/IWETH9.sol";
 import {IWPowerPerp} from "../interfaces/IWPowerPerp.sol";
@@ -775,8 +777,8 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
     function _swapCallback(
         address _caller,
         address _tokenIn,
-        address, /*_tokenOut*/
-        uint24, /*_fee*/
+        address _tokenOut,
+        uint24 _fee,
         uint256 _amountToPay,
         bytes memory _callData,
         uint8 _callSource
@@ -799,7 +801,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             );
 
             IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                ControllerHelperDiamondStorage.getAddressAtSlot(3),
+                _getPool(_tokenIn, _tokenOut, _fee),
                 _amountToPay
             );
             IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
@@ -834,7 +836,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             }
 
             IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
-                ControllerHelperDiamondStorage.getAddressAtSlot(3),
+                _getPool(_tokenIn, _tokenOut, _fee),
                 _amountToPay
             );
         } else if (
@@ -842,7 +844,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTIN_WPOWERPERP_ETH
         ) {
             IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
-                ControllerHelperDiamondStorage.getAddressAtSlot(3),
+                _getPool(_tokenIn, _tokenOut, _fee),
                 _amountToPay
             );
 
@@ -853,9 +855,10 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTOUT_ETH_WPOWERPERP
         ) {
             IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                ControllerHelperDiamondStorage.getAddressAtSlot(3),
+                _getPool(_tokenIn, _tokenOut, _fee),
                 _amountToPay
             );
+            return;
         } else if (
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTOUT_ETH_WPOWERPERP_BURN
@@ -874,14 +877,14 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             );
 
             IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                ControllerHelperDiamondStorage.getAddressAtSlot(3),
+                _getPool(_tokenIn, _tokenOut, _fee),
                 _amountToPay
             );
         } else if (
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
             ControllerHelperDataType.CALLBACK_SOURCE.GENERAL_SWAP
         ) {
-            IERC20(_tokenIn).transfer(ControllerHelperDiamondStorage.getAddressAtSlot(3), _amountToPay);
+            IERC20(_tokenIn).transfer(_getPool(_tokenIn, _tokenOut, _fee), _amountToPay);
         }
     }
 

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -775,8 +775,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
     function _swapCallback(
         address _caller,
         address _tokenIn,
-        address _tokenOut,
-        uint24 _fee,
+        address _pool,
         uint256 _amountToPay,
         bytes memory _callData,
         uint8 _callSource
@@ -799,7 +798,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             );
 
             IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                _getPool(_tokenIn, _tokenOut, _fee),
+                _pool,
                 _amountToPay
             );
             IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
@@ -834,7 +833,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             }
 
             IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
-                _getPool(_tokenIn, _tokenOut, _fee),
+                _pool,
                 _amountToPay
             );
         } else if (
@@ -842,7 +841,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTIN_WPOWERPERP_ETH
         ) {
             IWPowerPerp(ControllerHelperDiamondStorage.getAddressAtSlot(4)).transfer(
-                _getPool(_tokenIn, _tokenOut, _fee),
+                _pool,
                 _amountToPay
             );
 
@@ -853,7 +852,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             ControllerHelperDataType.CALLBACK_SOURCE.SWAP_EXACTOUT_ETH_WPOWERPERP
         ) {
             IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                _getPool(_tokenIn, _tokenOut, _fee),
+                _pool,
                 _amountToPay
             );
             return;
@@ -875,14 +874,14 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
             );
 
             IWETH9(ControllerHelperDiamondStorage.getAddressAtSlot(5)).transfer(
-                _getPool(_tokenIn, _tokenOut, _fee),
+                _pool,
                 _amountToPay
             );
         } else if (
             ControllerHelperDataType.CALLBACK_SOURCE(_callSource) ==
             ControllerHelperDataType.CALLBACK_SOURCE.GENERAL_SWAP
         ) {
-            IERC20(_tokenIn).transfer(_getPool(_tokenIn, _tokenOut, _fee), _amountToPay);
+            IERC20(_tokenIn).transfer(_pool, _amountToPay);
         }
     }
 

--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -3,8 +3,6 @@
 pragma solidity =0.7.6;
 pragma abicoder v2;
 
-import "hardhat/console.sol";
-
 // interface
 import {IWETH9} from "../interfaces/IWETH9.sol";
 import {IWPowerPerp} from "../interfaces/IWPowerPerp.sol";

--- a/packages/hardhat/contracts/periphery/UniswapControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/UniswapControllerHelper.sol
@@ -64,7 +64,7 @@ contract UniswapControllerHelper is IUniswapV3SwapCallback {
         uint256 amountToPay = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
 
         //calls the function that uses the proceeds from flash swap and executes logic to have an amount of token to repay the flash swap
-        _swapCallback(data.caller, tokenIn, tokenOut, fee, amountToPay, data.callData, data.callSource);
+        _swapCallback(data.caller, tokenIn, pool, amountToPay, data.callData, data.callSource);
     }
 
     /**
@@ -155,8 +155,7 @@ contract UniswapControllerHelper is IUniswapV3SwapCallback {
     function _swapCallback(
         address _caller,
         address _tokenIn,
-        address _tokenOut,
-        uint24 _fee,
+        address _pool,
         uint256 _amountToPay,
         bytes memory _callData,
         uint8 _callSource

--- a/packages/hardhat/contracts/periphery/UniswapControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/UniswapControllerHelper.sol
@@ -7,6 +7,7 @@ pragma abicoder v2;
 import "@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol";
 import "@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3FlashCallback.sol";
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {IERC20Detailed} from "../interfaces/IERC20Detailed.sol";
 
 // lib
 import "@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol";
@@ -58,7 +59,7 @@ contract UniswapControllerHelper is IUniswapV3SwapCallback {
         (address tokenIn, address tokenOut, uint24 fee) = data.path.decodeFirstPool();
 
         //ensure that callback comes from uniswap pool
-        CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
+        address pool = address(CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee));
 
         //determine the amount that needs to be repaid as part of the flashswap
         uint256 amountToPay = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
@@ -153,11 +154,11 @@ contract UniswapControllerHelper is IUniswapV3SwapCallback {
      * param _callSource function call source
      */
     function _swapCallback(
-        address, /*_caller*/
-        address, /*_tokenIn*/
-        address, /*_tokenOut*/
-        uint24, /*_fee*/
-        uint256, /*_amountToPay*/
+        address _caller,
+        address _tokenIn,
+        address _tokenOut,
+        uint24 _fee,
+        uint256 _amountToPay,
         bytes memory _callData,
         uint8 _callSource
     ) internal virtual {}
@@ -182,7 +183,7 @@ contract UniswapControllerHelper is IUniswapV3SwapCallback {
         bool zeroForOne = tokenIn < tokenOut;
 
         //swap on uniswap, including data to trigger call back for flashswap
-        (int256 amount0, int256 amount1) = _getPool(tokenIn, tokenOut, fee).swap(
+        (int256 amount0, int256 amount1) = IUniswapV3Pool(_getPool(tokenIn, tokenOut, fee)).swap(
             _recipient,
             zeroForOne,
             _amountIn.toInt256(),
@@ -217,7 +218,7 @@ contract UniswapControllerHelper is IUniswapV3SwapCallback {
         bool zeroForOne = tokenIn < tokenOut;
 
         //swap on uniswap, including data to trigger call back for flashswap
-        (int256 amount0Delta, int256 amount1Delta) = _getPool(tokenIn, tokenOut, fee).swap(
+        (int256 amount0Delta, int256 amount1Delta) = IUniswapV3Pool(_getPool(tokenIn, tokenOut, fee)).swap(
             _recipient,
             zeroForOne,
             -_amountOut.toInt256(),
@@ -249,7 +250,7 @@ contract UniswapControllerHelper is IUniswapV3SwapCallback {
         address tokenA,
         address tokenB,
         uint24 fee
-    ) private view returns (IUniswapV3Pool) {
-        return IUniswapV3Pool(PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee)));
+    ) internal view returns (address) {
+        return PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee));
     }
 }

--- a/packages/hardhat/contracts/periphery/UniswapControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/UniswapControllerHelper.sol
@@ -7,7 +7,6 @@ pragma abicoder v2;
 import "@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol";
 import "@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3FlashCallback.sol";
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
-import {IERC20Detailed} from "../interfaces/IERC20Detailed.sol";
 
 // lib
 import "@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol";


### PR DESCRIPTION
# Fix: using different uniswap pool in flashswapWBurnBuyLong() and flashswapSellLongWMint()

## Description

Fixes #442 #441 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
