### PR TITLE
Include flashloan amount in collateralToDeposit to allow user to use vault collateral to LP

### DIFF
--- a/packages/hardhat/contracts/periphery/ControllerHelper.sol
+++ b/packages/hardhat/contracts/periphery/ControllerHelper.sol
@@ -490,7 +490,7 @@ contract ControllerHelper is UniswapControllerHelper, EulerControllerHelper, IER
                     wPowerPerpPool: ControllerHelperDiamondStorage.getAddressAtSlot(3),
                     vaultId: data.vaultId,
                     wPowerPerpAmount: data.wPowerPerpAmount,
-                    collateralToDeposit: data.collateralToDeposit.add(data.collateralToFlashloan),
+                    collateralToDeposit: data.collateralToDeposit,
                     collateralToLp: data.collateralToLp,
                     amount0Min: data.lpAmount0Min,
                     amount1Min: data.lpAmount1Min,

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
@@ -100,7 +100,7 @@ library ControllerHelperDataType {
     struct FlashloanWMintDepositNftParams {
         uint256 vaultId; // vault ID (could be zero)
         uint256 wPowerPerpAmount; // wPowerPerp amount to mint
-        uint256 collateralToDeposit; // ETH collateral amount to deposit in vault (including the flashloaned amount)
+        uint256 collateralToDeposit; // ETH collateral amount to deposit in vault (including the flashloaned amount to use as collateral in vault)
         uint256 collateralToFlashloan; // ETH amount to flashloan and use for deposit into vault
         uint256 collateralToLp; // ETH collateral amount to use for LPing (could be zero)
         uint256 collateralToWithdraw; // ETH amount to withdraw from vault (if collateralToLp>0, this should be = collateralToLp+fee or 50% of collateralToLP and sender include the rest in msg.value)

--- a/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
+++ b/packages/hardhat/contracts/periphery/lib/ControllerHelperDataType.sol
@@ -100,7 +100,7 @@ library ControllerHelperDataType {
     struct FlashloanWMintDepositNftParams {
         uint256 vaultId; // vault ID (could be zero)
         uint256 wPowerPerpAmount; // wPowerPerp amount to mint
-        uint256 collateralToDeposit; // ETH collateral amount to deposit in vault (could be zero)
+        uint256 collateralToDeposit; // ETH collateral amount to deposit in vault (including the flashloaned amount)
         uint256 collateralToFlashloan; // ETH amount to flashloan and use for deposit into vault
         uint256 collateralToLp; // ETH collateral amount to use for LPing (could be zero)
         uint256 collateralToWithdraw; // ETH amount to withdraw from vault (if collateralToLp>0, this should be = collateralToLp+fee or 50% of collateralToLP and sender include the rest in msg.value)

--- a/packages/hardhat/test/e2e/periphery/controller-helper.ts
+++ b/packages/hardhat/test/e2e/periphery/controller-helper.ts
@@ -124,7 +124,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: 0,
         wPowerPerpAmount: mintWSqueethAmount.toString(),
-        collateralToDeposit: BigNumber.from(0),
+        collateralToDeposit: collateralToMint.toString(),
         collateralToFlashloan: collateralToMint.toString(),
         collateralToLp: collateralToLp.toString(),
         collateralToWithdraw: 0,
@@ -168,7 +168,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: 0,
         wPowerPerpAmount: mintWSqueethAmount.mul(2).toString(),
-        collateralToDeposit: BigNumber.from(0),
+        collateralToDeposit: collateralToMint.mul(2).toString(),
         collateralToFlashloan: collateralToMint.mul(2).toString(),
         collateralToLp: collateralToLp.toString(),
         collateralToWithdraw: 0,
@@ -283,7 +283,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: 0,
         wPowerPerpAmount: mintWSqueethAmount.toString(),
-        collateralToDeposit: collateralToMint.sub(collateralToFlashloan).toString(),
+        collateralToDeposit: collateralToMint.toString(),
         collateralToFlashloan: collateralToFlashloan.toString(),
         collateralToLp: BigNumber.from(0),
         collateralToWithdraw: 0,
@@ -324,7 +324,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: 0,
         wPowerPerpAmount: mintWSqueethAmount.toString(),
-        collateralToDeposit: collateralToMint.sub(collateralToFlashloan).toString(),
+        collateralToDeposit: collateralToMint.toString(),
         collateralToFlashloan: collateralToFlashloan.toString(),
         collateralToLp: collateralToLp.toString(),
         collateralToWithdraw: 0,
@@ -374,7 +374,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: vaultId,
         wPowerPerpAmount: mintWSqueethAmount.toString(),
-        collateralToDeposit: collateralToMint.sub(collateralToFlashloan).toString(),
+        collateralToDeposit: collateralToMint.toString(),
         collateralToFlashloan: collateralToFlashloan.toString(),
         collateralToLp: collateralToLp.toString(),
         collateralToWithdraw: 0,
@@ -448,7 +448,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: vaultId,
         wPowerPerpAmount: mintWSqueethAmount,
-        collateralToDeposit: BigNumber.from(0),
+        collateralToDeposit: debtInEth,
         collateralToFlashloan: debtInEth,
         collateralToLp: BigNumber.from(0),
         collateralToWithdraw: 0,
@@ -515,7 +515,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: vaultId.toString(),
         wPowerPerpAmount: mintWSqueethAmount.toString(),
-        collateralToDeposit: collateralToDeposit.toString(),
+        collateralToDeposit: collateralToDeposit.add(debtInEth).toString(),
         collateralToFlashloan: debtInEth.toString(),
         collateralToLp: BigNumber.from(0),
         collateralToWithdraw: 0,
@@ -758,7 +758,7 @@ describe("ControllerHelper: mainnet fork", function () {
       const flashloanWMintDepositNftParams = {
         vaultId: 0,
         wPowerPerpAmount: mintWSqueethAmount.toString(),
-        collateralToDeposit: 0,
+        collateralToDeposit: collateralToFlashloan.toString(),
         collateralToFlashloan: collateralToFlashloan.toString(),
         collateralToLp: collateralToLp.toString(),
         collateralToWithdraw: 0,


### PR DESCRIPTION
# Fix: Include flashloan amount in collateralToDeposit to allow user to use vault collateral to LP

## Description

This PR remove adding the amount to flashloan to the collateral to deposit when minting and LP, there this will allow the user to user any extra amount flashloaned as amount to LP,  and will repaid later when withdrawing from vault.

In the function call, the amount to flashloan and to use as vault collateral should be added in the collateral to deposit param.

Fixes #399 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change
