### PR TITLE
[BugFix] getContractAt picks up the contract at the deployer address;…

### DIFF
--- a/packages/hardhat/tasks/addSqueethLiquidity.ts
+++ b/packages/hardhat/tasks/addSqueethLiquidity.ts
@@ -30,8 +30,8 @@ task("addSqueethLiquidity", "Add liquidity to wsqueeth pool")
   const { deployer } = await getNamedAccounts();
   const { positionManager, uniswapFactory } = await getUniswapDeployments(ethers, deployer, network.name)
 
-  const controller = await ethers.getContractAt("Controller", deployer);
-  const wsqueeth = await ethers.getContractAt("WPowerPerp", deployer);
+  const controller = await ethers.getContract("Controller", deployer);
+  const wsqueeth = await ethers.getContract("WPowerPerp", deployer);
   const weth = await getWETH(ethers, deployer, network.name)
 
   const isWethToken0 = parseInt(weth.address, 16) < parseInt(wsqueeth.address, 16)

--- a/packages/hardhat/test/unit-tests/controller.ts
+++ b/packages/hardhat/test/unit-tests/controller.ts
@@ -391,7 +391,8 @@ describe("Controller", function () {
 
       it("Should revert when trying to use mint to deposit to a vault where msg.sender is not owner or operator", async() => {
         const depositAmount = ethers.utils.parseUnits('45')
-
+        const vaultId = await shortSqueeth.nextId()
+        await controller.connect(seller1).mintPowerPerpAmount(0, 0, 0) // putting vaultId = 0 to open vault
         await expect(controller.connect(random).deposit(vaultId,{value: depositAmount})).to.be.revertedWith(
           'C20'
         )


### PR DESCRIPTION
… changed to getContract

# Task:
Onboarding task . Add needed liquidity to local network
## Description
getContractAt picks up the contract at the deployer address; changed to getContract

Fixes # (issue)
npx hardhat addSqueethLiquidity --wsqueeth-amount 0.0004 --collateral-amount 2 --base-price 3300 --range 2x

## Type of change
Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
npx hardhat addSqueethLiquidity --wsqueeth-amount 0.0004 --collateral-amount 2 --base-price 3300 --range 2x
