### PR TITLE
fix advanced details close button overlapping Norm Factor tooltip

### DIFF
--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -4,8 +4,8 @@ import { createStyles, makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
 import InfoIcon from '@material-ui/icons/InfoOutlined'
-import ExpandLessIcon from '@material-ui/icons/NavigateBefore'
 import ExpandMoreIcon from '@material-ui/icons/NavigateNext'
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown'
 import Image from 'next/image'
 import { useState } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
@@ -478,77 +478,63 @@ const SqueethInfo: React.FC = () => {
         </div>
       </div>
       <div>
+        {/* hard coded width layout to align with the prev line */}
         <div className={classes.squeethInfoSubGroup}>
-          {/* hard coded width layout to align with the prev line */}
-          {!showAdvanced ? (
-            <>
-              <button className={classes.advancedDetails} onClick={() => setShowAdvanced(true)}>
-                <Typography color="textSecondary" variant="body2">
-                  Advanced details
-                </Typography>
-                <ExpandMoreIcon htmlColor="#fff" />
-              </button>
-            </>
-          ) : (
-            <>
-              <div className={classes.infoItem}>
-                <div className={classes.infoLabel}>
-                  <Typography color="textSecondary" variant="body2">
-                    ETH&sup2; Price
-                  </Typography>
-                  <Tooltip title={Tooltips.SpotPrice}>
-                    <FiberManualRecordIcon fontSize="small" className={classes.infoIcon} />
-                  </Tooltip>
-                </div>
-                <Typography>${Number(toTokenAmount(index, 18).toFixed(0)).toLocaleString() || 'loading'}</Typography>
-              </div>
-              <div className={classes.infoItem}>
-                <div className={classes.infoLabel}>
-                  <Typography color="textSecondary" variant="body2">
-                    Mark Price
-                  </Typography>
-                  <Tooltip title={`${Tooltips.Mark}. ${Tooltips.SpotPrice}`}>
-                    <FiberManualRecordIcon fontSize="small" className={classes.infoIcon} />
-                  </Tooltip>
-                </div>
-                <Typography>${Number(toTokenAmount(mark, 18).toFixed(0)).toLocaleString() || 'loading'}</Typography>
-              </div>
-              <div className={classes.infoItem}>
-                <div className={classes.infoLabel}>
-                  <Typography color="textSecondary" variant="body2">
-                    Implied Volatility
-                  </Typography>
-                  <Tooltip title={Tooltips.ImplVol}>
-                    <InfoIcon fontSize="small" className={classes.infoIcon} />
-                  </Tooltip>
-                </div>
-                <Typography>{(impliedVol * 100).toFixed(2)}%</Typography>
-              </div>
-              <div className={classes.infoItem}>
-                <div className={classes.infoLabel}>
-                  <Typography color="textSecondary" variant="body2">
-                    Norm Factor
-                  </Typography>
-                  <Tooltip title={Tooltips.NormFactor}>
-                    <InfoIcon fontSize="small" className={classes.infoIcon} />
-                  </Tooltip>
-                </div>
-                <Typography>{normFactor.toFixed(4)}</Typography>
-              </div>
-
-              <IconButton
-                style={{ position: 'absolute', right: 0 }}
-                className={classes.arrowBtn}
-                onClick={() => setShowAdvanced(false)}
-              >
-                <ExpandLessIcon />
-              </IconButton>
-
-              {/*  */}
-              {/* <div className={classes.infoItem}></div> */}
-            </>
-          )}
+          <button className={classes.advancedDetails} onClick={() => setShowAdvanced((prevState) => !prevState)}>
+            <Typography color="textSecondary" variant="body2">
+              Advanced details
+            </Typography>
+            {!showAdvanced ? <ExpandMoreIcon htmlColor="#fff" /> : <KeyboardArrowDownIcon htmlColor="#fff" />}
+          </button>
         </div>
+        {showAdvanced ? (
+          <div className={classes.squeethInfoSubGroup}>
+            <div className={classes.infoItem}>
+              <div className={classes.infoLabel}>
+                <Typography color="textSecondary" variant="body2">
+                  ETH&sup2; Price
+                </Typography>
+                <Tooltip title={Tooltips.SpotPrice}>
+                  <FiberManualRecordIcon fontSize="small" className={classes.infoIcon} />
+                </Tooltip>
+              </div>
+              <Typography>${Number(toTokenAmount(index, 18).toFixed(0)).toLocaleString() || 'loading'}</Typography>
+            </div>
+            <div className={classes.infoItem}>
+              <div className={classes.infoLabel}>
+                <Typography color="textSecondary" variant="body2">
+                  Mark Price
+                </Typography>
+                <Tooltip title={`${Tooltips.Mark}. ${Tooltips.SpotPrice}`}>
+                  <FiberManualRecordIcon fontSize="small" className={classes.infoIcon} />
+                </Tooltip>
+              </div>
+              <Typography>${Number(toTokenAmount(mark, 18).toFixed(0)).toLocaleString() || 'loading'}</Typography>
+            </div>
+            <div className={classes.infoItem}>
+              <div className={classes.infoLabel}>
+                <Typography color="textSecondary" variant="body2">
+                  Implied Volatility
+                </Typography>
+                <Tooltip title={Tooltips.ImplVol}>
+                  <InfoIcon fontSize="small" className={classes.infoIcon} />
+                </Tooltip>
+              </div>
+              <Typography>{(impliedVol * 100).toFixed(2)}%</Typography>
+            </div>
+            <div className={classes.infoItem}>
+              <div className={classes.infoLabel}>
+                <Typography color="textSecondary" variant="body2">
+                  Norm Factor
+                </Typography>
+                <Tooltip title={Tooltips.NormFactor}>
+                  <InfoIcon fontSize="small" className={classes.infoIcon} />
+                </Tooltip>
+              </div>
+              <Typography>{normFactor.toFixed(4)}</Typography>
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -1,11 +1,11 @@
-import { Hidden, IconButton, Tooltip } from '@material-ui/core'
+import { Hidden, Tooltip } from '@material-ui/core'
 import Card from '@material-ui/core/Card'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
 import InfoIcon from '@material-ui/icons/InfoOutlined'
-import ExpandMoreIcon from '@material-ui/icons/NavigateNext'
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown'
+import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp'
 import Image from 'next/image'
 import { useState } from 'react'
 import { useAtom, useAtomValue } from 'jotai'
@@ -479,14 +479,7 @@ const SqueethInfo: React.FC = () => {
       </div>
       <div>
         {/* hard coded width layout to align with the prev line */}
-        <div className={classes.squeethInfoSubGroup}>
-          <button className={classes.advancedDetails} onClick={() => setShowAdvanced((prevState) => !prevState)}>
-            <Typography color="textSecondary" variant="body2">
-              Advanced details
-            </Typography>
-            {!showAdvanced ? <ExpandMoreIcon htmlColor="#fff" /> : <KeyboardArrowDownIcon htmlColor="#fff" />}
-          </button>
-        </div>
+
         {showAdvanced ? (
           <div className={classes.squeethInfoSubGroup}>
             <div className={classes.infoItem}>
@@ -535,6 +528,15 @@ const SqueethInfo: React.FC = () => {
             </div>
           </div>
         ) : null}
+        <div className={classes.squeethInfoSubGroup}>
+          <button className={classes.advancedDetails} onClick={() => setShowAdvanced((prevState) => !prevState)}>
+            <Typography color="textSecondary" variant="body2">
+              Advanced details
+            </Typography>
+
+            {!showAdvanced ? <KeyboardArrowDownIcon htmlColor="#fff" /> : <KeyboardArrowUpIcon htmlColor="#fff" />}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/packages/frontend/src/components/PositionCard.tsx
+++ b/packages/frontend/src/components/PositionCard.tsx
@@ -48,6 +48,7 @@ const useStyles = makeStyles((theme) =>
     container: {
       padding: theme.spacing(2),
       width: '420px',
+      alignSelf: 'flex-start',
       // background: theme.palette.background.lightStone,
       borderRadius: theme.spacing(1),
       display: 'flex',


### PR DESCRIPTION
# Task:

## Description

Issue: When the advanced details dropdown is open and the arrow is hovered over prior to closing it, the shaded area overlaps with the Norm Factor tooltip. 

This change makes it like an accordion, such that user can open and close with the same button.
<img width="641" alt="Screenshot 2022-05-23 at 18 37 56" src="https://user-images.githubusercontent.com/40301524/169876319-dc22e3c3-8e5d-4b78-8c5f-63e10bc403e1.png">

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## FE Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change

## User Facing Checklist

- [ ] I fully understand the user problem this PR is solving
- [ ] I know who the target user is for this PR and have a deep understanding of that user
- [ ] I have tried this flow thinking from the pov of the target user for this PR
- [ ] I (or working w someone on team) have scheduled a user test for this PR (if it is a large change)
