### PR TITLE
fix debtInEth calcs

### DIFF
--- a/packages/hardhat/test/e2e/periphery/controller-helper.ts
+++ b/packages/hardhat/test/e2e/periphery/controller-helper.ts
@@ -582,7 +582,9 @@ describe("ControllerHelper: mainnet fork", function () {
       const vaultBefore = await controller.vaults(vaultId); 
       const ethPrice = await oracle.getTwap(ethUsdcPool.address, weth.address, usdc.address, 420, true)
       const scaledEthPrice = ethPrice.div(10000)
-      const debtInEth = vaultBefore.shortAmount.mul(scaledEthPrice).div(one)
+      const normFactor = await controller.getExpectedNormalizationFactor()
+      const scaledShortAmount = vaultBefore.shortAmount.mul(normFactor).div(one)
+      const debtInEth = scaledShortAmount.mul(scaledEthPrice).div(one)
       const collateralToFlashloan = debtInEth.mul(3).div(2).add(ethers.utils.parseUnits('0.01'))
       const squeethPrice = await oracle.getTwap(wSqueethPool.address, wSqueeth.address, weth.address, 420, true)
       const slippage = BigNumber.from(3).mul(BigNumber.from(10).pow(16))
@@ -677,7 +679,9 @@ describe("ControllerHelper: mainnet fork", function () {
       const vaultBefore = await controller.vaults(vaultId); 
       const ethPrice = await oracle.getTwap(ethUsdcPool.address, weth.address, usdc.address, 420, true)
       const scaledEthPrice = ethPrice.div(10000)
-      const debtInEth = vaultBefore.shortAmount.mul(scaledEthPrice).div(one)
+      const normFactor = await controller.getExpectedNormalizationFactor()
+      const scaledShortAmount = vaultBefore.shortAmount.mul(normFactor).div(one)
+      const debtInEth = scaledShortAmount.mul(scaledEthPrice).div(one)
       const collateralToFlashloan = debtInEth.mul(3).div(2).add(ethers.utils.parseUnits('0.01'))
       const squeethPrice = await oracle.getTwap(wSqueethPool.address, wSqueeth.address, weth.address, 420, true)
       const slippage = BigNumber.from(3).mul(BigNumber.from(10).pow(16))
@@ -793,7 +797,9 @@ describe("ControllerHelper: mainnet fork", function () {
       const vaultBefore = await controller.vaults(vaultId); 
       const ethPrice = await oracle.getTwap(ethUsdcPool.address, weth.address, usdc.address, 420, true)
       const scaledEthPrice = ethPrice.div(10000)
-      const debtInEth = vaultBefore.shortAmount.mul(scaledEthPrice).div(one)
+      const normFactor = await controller.getExpectedNormalizationFactor()
+      const scaledShortAmount = vaultBefore.shortAmount.mul(normFactor).div(one)
+      const debtInEth = scaledShortAmount.mul(scaledEthPrice).div(one)
       const collateralToFlashloan = debtInEth.mul(3).div(2).add(ethers.utils.parseUnits('0.01'))
       const positionBefore = await (positionManager as INonfungiblePositionManager).positions(uniTokenId);
 


### PR DESCRIPTION
# Task:

Fix debtInEth calcs for three tests.

## Description

Three tests calculating debtInEth without normFactor. Fixed for these tests

Was
      `const scaledEthPrice = ethPrice.div(10000)`
      `const debtInEth = vaultBefore.shortAmount.mul(scaledEthPrice).div(one)`
      
Now we

      `const scaledEthPrice = ethPrice.div(10000)`
      `const normFactor = await controller.getExpectedNormalizationFactor()`
      `const scaledShortAmount = vaultBefore.shortAmount.mul(normFactor).div(one)`
      `const debtInEth = scaledShortAmount.mul(scaledEthPrice).div(one)`

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## FE Checklist

- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change

## User Facing Checklist

- [x ] I fully understand the user problem this PR is solving
- [ x] I know who the target user is for this PR and have a deep understanding of that user
- [x ] I have tried this flow thinking from the pov of the target user for this PR
- [ ] I (or working w someone on team) have scheduled a user test for this PR (if it is a large change)
