### PR TITLE
Fix addSqueethLiquidty.ts task error

### DIFF
--- a/packages/hardhat/tasks/addSqueethLiquidity.ts
+++ b/packages/hardhat/tasks/addSqueethLiquidity.ts
@@ -30,8 +30,8 @@ task("addSqueethLiquidity", "Add liquidity to wsqueeth pool")
   const { deployer } = await getNamedAccounts();
   const { positionManager, uniswapFactory } = await getUniswapDeployments(ethers, deployer, network.name)
 
-  const controller = await ethers.getContractAt("Controller", deployer);
-  const wsqueeth = await ethers.getContractAt("WPowerPerp", deployer);
+  const controller = await ethers.getContract("Controller", deployer);
+  const wsqueeth = await ethers.getContract("WPowerPerp", deployer);
   const weth = await getWETH(ethers, deployer, network.name)
 
   const isWethToken0 = parseInt(weth.address, 16) < parseInt(wsqueeth.address, 16)


### PR DESCRIPTION
# Task: Fix addSqueethLiquidty.ts task error

## Description

Using `getContractAt()` returns incorrect addresses for `wsqueeth` and `controller`. These have now been changed to `getContract()`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Run the task. For example:
`npx hardhat addSqueethLiquidity --network ropsten --wsqueeth-amount 0.0004 --collateral-amount 2 --base-price 3300 --range 2x` 

## FE Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change

## User Facing Checklist

- [ ] I fully understand the user problem this PR is solving
- [ ] I know who the target user is for this PR and have a deep understanding of that user
- [ ] I have tried this flow thinking from the pov of the target user for this PR
- [ ] I (or working w someone on team) have scheduled a user test for this PR (if it is a large change)
