### PR TITLE
Feat/short long warnings

### DIFF
--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -364,7 +364,8 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
     }
   }
 
-  const longOpenPriceImpactErrorState = priceImpactWarning && !buyLoading && !openError && !isShort
+  const longOpenPriceImpactErrorState = priceImpactWarning && !buyLoading && !openError
+  const longOpenShortOpenErrorState = isShort && !buyLoading && !openError && !priceImpactWarning
 
   useAppEffect(() => {
     if (transactionInProgress) {
@@ -560,7 +561,11 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
                   </PrimaryButton>
                 ) : (
                   <PrimaryButton
-                    variant={longOpenPriceImpactErrorState || !!highVolError ? 'outlined' : 'contained'}
+                    variant={
+                      longOpenPriceImpactErrorState || !!highVolError || longOpenShortOpenErrorState
+                        ? 'outlined'
+                        : 'contained'
+                    }
                     onClick={transact}
                     className={classes.amountInput}
                     disabled={
@@ -568,11 +573,10 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
                       !!buyLoading ||
                       transactionInProgress ||
                       !!openError ||
-                      !!existingShortError ||
                       sqthTradeAmount === '0'
                     }
                     style={
-                      longOpenPriceImpactErrorState || !!highVolError
+                      longOpenPriceImpactErrorState || !!highVolError || longOpenShortOpenErrorState
                         ? { width: '300px', color: '#f5475c', backgroundColor: 'transparent', borderColor: '#f5475c' }
                         : { width: '300px' }
                     }
@@ -582,7 +586,7 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
                       'Unsupported Network'
                     ) : buyLoading || transactionInProgress ? (
                       <CircularProgress color="primary" size="1.5rem" />
-                    ) : longOpenPriceImpactErrorState ? (
+                    ) : longOpenPriceImpactErrorState || longOpenShortOpenErrorState ? (
                       'Buy Anyway'
                     ) : (
                       'Buy'
@@ -685,8 +689,10 @@ const CloseLong: React.FC<BuyProps> = () => {
     }
   }
 
-  const longClosePriceImpactErrorState =
-    priceImpactWarning && !closeError && !sellLoading && !squeethAmount.isZero() && !isShort
+  const longClosePriceImpactErrorState = priceImpactWarning && !closeError && !sellLoading && !squeethAmount.isZero()
+
+  const longCloseShortOpenErrorState =
+    isShort && !closeError && !sellLoading && !squeethAmount.isZero() && !priceImpactWarning
 
   const sellAndClose = useAppCallback(async () => {
     setSellLoading(true)
@@ -914,7 +920,7 @@ const CloseLong: React.FC<BuyProps> = () => {
               </PrimaryButton>
             ) : (
               <PrimaryButton
-                variant={longClosePriceImpactErrorState ? 'outlined' : 'contained'}
+                variant={longClosePriceImpactErrorState || longCloseShortOpenErrorState ? 'outlined' : 'contained'}
                 onClick={sellAndClose}
                 className={classes.amountInput}
                 disabled={
@@ -922,12 +928,11 @@ const CloseLong: React.FC<BuyProps> = () => {
                   !!sellLoading ||
                   transactionInProgress ||
                   !!closeError ||
-                  !!existingShortError ||
                   squeethAmount.isZero() ||
                   sqthTradeAmount === '0'
                 }
                 style={
-                  longClosePriceImpactErrorState
+                  longClosePriceImpactErrorState || longCloseShortOpenErrorState
                     ? { width: '300px', color: '#f5475c', backgroundColor: 'transparent', borderColor: '#f5475c' }
                     : { width: '300px' }
                 }
@@ -939,7 +944,7 @@ const CloseLong: React.FC<BuyProps> = () => {
                   <CircularProgress color="primary" size="1.5rem" />
                 ) : squeethAllowance.lt(amount) && !hasJustApprovedSqueeth ? (
                   'Approve oSQTH (1/2)'
-                ) : longClosePriceImpactErrorState ? (
+                ) : longClosePriceImpactErrorState || longCloseShortOpenErrorState ? (
                   'Sell Anyway'
                 ) : hasJustApprovedSqueeth ? (
                   'Sell to close (2/2)'

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -418,6 +418,9 @@ const OpenShort: React.FC<SellType> = ({ open }) => {
   const shortOpenPriceImpactErrorState =
     priceImpactWarning && !shortLoading && !(collatPercent < 150) && !openError && !existingLongError
 
+  const shortOpenLongOpenErrorState =
+    existingLongError && !shortLoading && !(collatPercent < 150) && !openError && !priceImpactWarning
+
   useAppEffect(() => {
     setCollatRatio(collatPercent / 100)
   }, [collatPercent, setCollatRatio])
@@ -633,13 +636,12 @@ const OpenShort: React.FC<SellType> = ({ open }) => {
                   transactionInProgress ||
                   collatPercent < 150 ||
                   !!openError ||
-                  !!existingLongError ||
                   (vault && vault.shortAmount.isZero()) ||
                   !!vaultIdDontLoadedError
                 }
-                variant={shortOpenPriceImpactErrorState ? 'outlined' : 'contained'}
+                variant={shortOpenPriceImpactErrorState || shortOpenLongOpenErrorState ? 'outlined' : 'contained'}
                 style={
-                  shortOpenPriceImpactErrorState
+                  shortOpenPriceImpactErrorState || shortOpenLongOpenErrorState
                     ? { width: '300px', color: '#f5475c', backgroundColor: 'transparent', borderColor: '#f5475c' }
                     : { width: '300px' }
                 }
@@ -651,10 +653,10 @@ const OpenShort: React.FC<SellType> = ({ open }) => {
                   <CircularProgress color="primary" size="1.5rem" />
                 ) : (
                   <>
-                    {isVaultApproved
-                      ? 'Deposit and sell'
-                      : shortOpenPriceImpactErrorState && isVaultApproved
+                    {(shortOpenPriceImpactErrorState && isVaultApproved) || (existingLongError && isVaultApproved)
                       ? 'Deposit and sell anyway'
+                      : isVaultApproved
+                      ? 'Deposit and sell'
                       : 'Allow wrapper to manage vault (1/2)'}
                     {!isVaultApproved ? (
                       <Tooltip style={{ marginLeft: '2px' }} title={Tooltips.Operator}>
@@ -883,6 +885,15 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
     !(collatPercent < 150) &&
     !closeError &&
     !existingLongError &&
+    vault &&
+    !vault.shortAmount.isZero()
+
+  const shortCloseLongOpenErrorState =
+    existingLongError &&
+    !buyLoading &&
+    !(collatPercent < 150) &&
+    !closeError &&
+    !priceImpactWarning &&
     vault &&
     !vault.shortAmount.isZero()
 
@@ -1143,14 +1154,13 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
                   transactionInProgress ||
                   collatPercent < 150 ||
                   !!closeError ||
-                  !!existingLongError ||
                   (vault && vault.shortAmount.isZero()) ||
                   !!vaultIdDontLoadedError ||
                   !!insufficientETHBalance
                 }
-                variant={shortClosePriceImpactErrorState ? 'outlined' : 'contained'}
+                variant={shortClosePriceImpactErrorState || shortCloseLongOpenErrorState ? 'outlined' : 'contained'}
                 style={
-                  shortClosePriceImpactErrorState
+                  shortClosePriceImpactErrorState || shortCloseLongOpenErrorState
                     ? { width: '300px', color: '#f5475c', backgroundColor: 'transparent', borderColor: '#f5475c' }
                     : { width: '300px' }
                 }
@@ -1164,7 +1174,7 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
                   <>
                     {isVaultApproved
                       ? 'Buy back and close'
-                      : shortClosePriceImpactErrorState && isVaultApproved
+                      : (shortClosePriceImpactErrorState && isVaultApproved) || (existingLongError && isVaultApproved)
                       ? 'Buy back and close anyway'
                       : 'Allow wrapper to manage vault (1/2)'}
                     {!isVaultApproved ? (

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -415,8 +415,7 @@ const OpenShort: React.FC<SellType> = ({ open }) => {
     }
   }
 
-  const shortOpenPriceImpactErrorState =
-    priceImpactWarning && !shortLoading && !(collatPercent < 150) && !openError && !existingLongError
+  const shortOpenPriceImpactErrorState = priceImpactWarning && !shortLoading && !(collatPercent < 150) && !openError
 
   const shortOpenLongOpenErrorState =
     existingLongError && !shortLoading && !(collatPercent < 150) && !openError && !priceImpactWarning
@@ -880,13 +879,7 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
   }
 
   const shortClosePriceImpactErrorState =
-    priceImpactWarning &&
-    !buyLoading &&
-    !(collatPercent < 150) &&
-    !closeError &&
-    !existingLongError &&
-    vault &&
-    !vault.shortAmount.isZero()
+    priceImpactWarning && !buyLoading && !(collatPercent < 150) && !closeError && vault && !vault.shortAmount.isZero()
 
   const shortCloseLongOpenErrorState =
     existingLongError &&


### PR DESCRIPTION
# Task: Allow users to go short even if they have some long position and vice versa by changing hard block into overrideable warning

## Description
Currently we only allow users to go short if they have closed out their full long and vice versa. However, many advanced users (especially ones that LP) can be long and short at the same time or have just amounts of either. Instead of hard blocking this scenario, we can have a warning that warns users they are going long while they still have a short or vice versa, which serves the purpose of preventing most people from taking that action, but doesn't frustrate or block advanced users who want access to that flow.

Opening & closing a long while have a short position:

https://user-images.githubusercontent.com/13340486/172070046-6b6c740f-e8d9-429c-bf41-13c7b6c70869.mov


Opening & closing a short while have a long position:

https://user-images.githubusercontent.com/13340486/172070080-7b4153af-aa89-420e-98a1-38782cfb6c54.mov


Fixes # (issue) #507 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Locally

## FE Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Added video recordings if it is a UI change


## User Facing Checklist

- [x] I fully understand the user problem this PR is solving
- [x] I know who the target user is for this PR and have a deep understanding of that user
- [x] I have tried this flow thinking from the pov of the target user for this PR
- [ ] I (or working w someone on team) have scheduled a user test for this PR (if it is a large change)
