### PR TITLE
Bug Fix: Remaining amount shoud be greater than the quantity

### DIFF
--- a/packages/hardhat/contracts/strategy/CrabStrategyV2.sol
+++ b/packages/hardhat/contracts/strategy/CrabStrategyV2.sol
@@ -685,7 +685,7 @@ contract CrabStrategyV2 is StrategyBase, StrategyFlashSwap, ReentrancyGuard, Own
 
             _execOrder(remainingAmount, _clearingPrice, _orders[i]);
 
-            if (remainingAmount >= _orders[i].quantity) {
+            if (remainingAmount > _orders[i].quantity) {
                 remainingAmount = remainingAmount.sub(_orders[i].quantity);
             } else {
                 break;


### PR DESCRIPTION
When remaining amount is greater than or equal to zero, we run the loop one extra time for the last order with zero quantity as remaining. This is not necessary