### PR TITLE
Slippage quote fix

### DIFF
--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -391,7 +391,7 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
       console.log(e)
       setBuyLoading(false)
     }
-  }, [buyAndRefund, ethTradeAmount, resetEthTradeAmount, resetSqthTradeAmount, setTradeCompleted, setTradeSuccess, slippageAmount])
+  }, [buyAndRefund, ethTradeAmount, resetEthTradeAmount, resetSqthTradeAmount, setTradeCompleted, setTradeSuccess])
 
   return (
     <div id="open-long-card">

--- a/packages/frontend/src/state/squeethPool/hooks.ts
+++ b/packages/frontend/src/state/squeethPool/hooks.ts
@@ -147,6 +147,7 @@ export const useGetBuyQuoteForETH = () => {
   const address = useAtomValue(addressAtom)
   const wethToken = useAtomValue(wethTokenAtom)
   const squeethToken = useAtomValue(squeethTokenAtom)
+  const slippageAmount = useAtomValue(slippageAmountAtom)
 
   //If I input an exact amount of ETH I want to spend, tells me how much Squeeth I'd purchase
   const getBuyQuoteForETH = useAppCallback(
@@ -187,7 +188,7 @@ export const useGetBuyQuoteForETH = () => {
       }
       return emptyState
     },
-    [pool, wethToken?.address, squeethToken?.address],
+    [pool, wethToken?.address, squeethToken?.address, slippageAmount],
   )
 
   return getBuyQuoteForETH

--- a/packages/frontend/src/state/squeethPool/hooks.ts
+++ b/packages/frontend/src/state/squeethPool/hooks.ts
@@ -168,7 +168,6 @@ export const useGetBuyQuoteForETH = () => {
           slippageTolerance: parseSlippageInput(slippageTolerance.toString()),
           deadline: Math.floor(Date.now()/1000 +1800)
         })
-        console.log("slippageTolerance", slippageTolerance.toString())
 
       if (!route) return null
 
@@ -499,7 +498,6 @@ export const useAutoRoutedGetSellQuote = () => {
         slippageTolerance: parseSlippageInput(slippageTolerance.toString()),
         deadline: Math.floor(Date.now()/1000 +1800)
       })
-      console.log("slippageTolerance", slippageTolerance.toString())
 
       if (!route) return null
 

--- a/packages/frontend/src/state/squeethPool/hooks.ts
+++ b/packages/frontend/src/state/squeethPool/hooks.ts
@@ -147,7 +147,6 @@ export const useGetBuyQuoteForETH = () => {
   const address = useAtomValue(addressAtom)
   const wethToken = useAtomValue(wethTokenAtom)
   const squeethToken = useAtomValue(squeethTokenAtom)
-  const slippageAmount = useAtomValue(slippageAmountAtom)
 
   //If I input an exact amount of ETH I want to spend, tells me how much Squeeth I'd purchase
   const getBuyQuoteForETH = useAppCallback(
@@ -169,6 +168,7 @@ export const useGetBuyQuoteForETH = () => {
           slippageTolerance: parseSlippageInput(slippageTolerance.toString()),
           deadline: Math.floor(Date.now()/1000 +1800)
         })
+        console.log("slippageTolerance", slippageTolerance.toString())
 
       if (!route) return null
 
@@ -188,7 +188,7 @@ export const useGetBuyQuoteForETH = () => {
       }
       return emptyState
     },
-    [pool, wethToken?.address, squeethToken?.address, slippageAmount],
+    [pool, wethToken?.address, squeethToken?.address],
   )
 
   return getBuyQuoteForETH
@@ -499,6 +499,7 @@ export const useAutoRoutedGetSellQuote = () => {
         slippageTolerance: parseSlippageInput(slippageTolerance.toString()),
         deadline: Math.floor(Date.now()/1000 +1800)
       })
+      console.log("slippageTolerance", slippageTolerance.toString())
 
       if (!route) return null
 

--- a/packages/frontend/src/state/squeethPool/hooks.ts
+++ b/packages/frontend/src/state/squeethPool/hooks.ts
@@ -147,7 +147,6 @@ export const useGetBuyQuoteForETH = () => {
   const address = useAtomValue(addressAtom)
   const wethToken = useAtomValue(wethTokenAtom)
   const squeethToken = useAtomValue(squeethTokenAtom)
-  const slippageAmount = useAtomValue(slippageAmountAtom)
 
   //If I input an exact amount of ETH I want to spend, tells me how much Squeeth I'd purchase
   const getBuyQuoteForETH = useAppCallback(
@@ -169,6 +168,7 @@ export const useGetBuyQuoteForETH = () => {
           slippageTolerance: parseSlippageInput(slippageTolerance.toString()),
           deadline: Math.floor(Date.now()/1000 +1800)
         })
+        console.log("slippageTolerance", slippageTolerance.toString())
 
       if (!route) return null
 
@@ -188,7 +188,7 @@ export const useGetBuyQuoteForETH = () => {
       }
       return emptyState
     },
-    [pool, wethToken?.address, squeethToken?.address, slippageAmount],
+    [pool, wethToken?.address, squeethToken?.address],
   )
 
   return getBuyQuoteForETH
@@ -477,7 +477,6 @@ export const useAutoRoutedGetSellQuote = () => {
   const networkId = useAtomValue(networkIdAtom)
   const web3 = useAtomValue(web3Atom)
   const address = useAtomValue(addressAtom)
-  const slippageAmount = useAtomValue(slippageAmountAtom)
 
   //I input an exact amount of squeeth I want to sell, tells me how much ETH I'd receive
   const getSellQuote = useAppCallback(
@@ -500,6 +499,7 @@ export const useAutoRoutedGetSellQuote = () => {
         slippageTolerance: parseSlippageInput(slippageTolerance.toString()),
         deadline: Math.floor(Date.now()/1000 +1800)
       })
+      console.log("slippageTolerance", slippageTolerance.toString())
 
       if (!route) return null
 
@@ -521,7 +521,7 @@ export const useAutoRoutedGetSellQuote = () => {
 
       return emptyState
     },
-    [pool, wethToken?.address, squeethToken?.address, slippageAmount],
+    [pool, wethToken?.address, squeethToken?.address],
   )
   return getSellQuote
 }


### PR DESCRIPTION
Before: using fixed slippage amount and overriding when sending minimum amount out
Now: using user inputted slippage amount from get-go