### PR TITLE
[Audit Fix] [L-7] - User crabV1 tokens can get stuck when the owner does not launch migrate

### DIFF
--- a/packages/hardhat/contracts/strategy/CrabMigration.sol
+++ b/packages/hardhat/contracts/strategy/CrabMigration.sol
@@ -140,6 +140,15 @@ contract CrabMigration is Ownable {
     }
 
     /**
+     * @notice allows users to withdraw their crab v1 shares in the pool before migration
+     * @param amount amount of V1 shares to withdraw
+     */
+    function withdrawV1Shares(uint256 amount) external beforeMigration {
+        sharesDeposited[msg.sender] = sharesDeposited[msg.sender].sub(amount);
+        crabV1.transfer(msg.sender, amount);
+    }
+
+    /**
      * @notice the owner batch migrates all the crab v1 shares in this contract to crab v2 and initializes
      * the v2 contract at the same collateral ratio as the v1 contract.
      */

--- a/packages/hardhat/contracts/strategy/CrabMigration.sol
+++ b/packages/hardhat/contracts/strategy/CrabMigration.sol
@@ -82,6 +82,8 @@ contract CrabMigration is Ownable {
 
     event ClaimAndWithdraw(address indexed user, uint256 crabAmount);
 
+    event WithdrawV1Shares(address indexed user, uint256 crabV1Amount);
+
     modifier beforeMigration() {
         require(!isMigrated, "M2");
         _;
@@ -146,6 +148,8 @@ contract CrabMigration is Ownable {
     function withdrawV1Shares(uint256 amount) external beforeMigration {
         sharesDeposited[msg.sender] = sharesDeposited[msg.sender].sub(amount);
         crabV1.transfer(msg.sender, amount);
+
+        emit WithdrawV1Shares(msg.sender, amount);
     }
 
     /**

--- a/packages/hardhat/contracts/strategy/CrabMigration.sol
+++ b/packages/hardhat/contracts/strategy/CrabMigration.sol
@@ -156,7 +156,7 @@ contract CrabMigration is Ownable {
      */
     function withdrawV1Shares(uint256 amount) external beforeMigration {
         sharesDeposited[msg.sender] = sharesDeposited[msg.sender].sub(amount);
-        crabV1.transfer(msg.sender, amount);
+        CrabStrategy(crabV1).transfer(msg.sender, amount);
 
         emit WithdrawV1Shares(msg.sender, amount);
     }

--- a/packages/hardhat/test/e2e/crab-Migration.ts
+++ b/packages/hardhat/test/e2e/crab-Migration.ts
@@ -183,6 +183,36 @@ describe("Crab Migration", function () {
             expect(d2SharesDeposited).to.be.equal(deposit2Amount);
         })
 
+        it("d2 withdraws too many crabV1 shares", async () => {
+            await expect(crabMigration.connect(d2).withdrawV1Shares(deposit2Amount.mul(2))).to.be.revertedWith('ds-math-sub-underflow');
+        })
+
+        it("d2 withdraws 1/2 of their crabV1 shares", async () => {
+            const crabV1BalanceBefore = await crabStrategyV1.balanceOf(crabMigration.address);
+
+            await crabMigration.connect(d2).withdrawV1Shares(deposit2Amount.div(2));
+
+            const crabV1BalanceAfter = await crabStrategyV1.balanceOf(crabMigration.address);
+            const d2SharesDeposited = await crabMigration.sharesDeposited(d2.address);
+
+            expect(crabV1BalanceBefore.sub(crabV1BalanceAfter)).to.be.equal(deposit2Amount.div(2));
+            expect(d2SharesDeposited).to.be.equal(deposit2Amount.sub(deposit2Amount.div(2)));
+        })
+
+        it("d2 re-deposits their withdrawn shares", async () => {
+            const crabV1BalanceBefore = await crabStrategyV1.balanceOf(crabMigration.address);
+
+            await crabStrategyV1.connect(d2).approve(crabMigration.address, deposit2Amount.div(2));
+            await crabMigration.connect(d2).depositV1Shares(deposit2Amount.div(2));
+
+            const crabV1BalanceAfter = await crabStrategyV1.balanceOf(crabMigration.address);
+            const d2SharesDeposited = await crabMigration.sharesDeposited(d2.address);
+
+            expect(crabV1BalanceAfter.sub(crabV1BalanceBefore)).to.be.equal(deposit2Amount.div(2));
+            expect(d2SharesDeposited).to.be.equal(deposit2Amount);
+        })
+
+
         it("should not be able to claim until strategy has been migrated", async () => {
             await expect(crabMigration.connect(d1).claimV2Shares()).to.be.revertedWith("M3");
         })
@@ -310,6 +340,11 @@ describe("Crab Migration", function () {
         it("d1 should not be able to deposit after migration", async () => {
             await expect(crabMigration.connect(d1).depositV1Shares(deposit1Amount)).to.be.revertedWith("M2");
         })
+
+        it("d1 should not be able to withdraw after migration", async () => {
+            await expect(crabMigration.connect(d1).withdrawV1Shares(deposit1Amount)).to.be.revertedWith("M2");
+        })
+
     })
 
     describe("Individual claim after migration", () => {

--- a/packages/hardhat/test/unit-tests/strategy/crab-migration.ts
+++ b/packages/hardhat/test/unit-tests/strategy/crab-migration.ts
@@ -129,7 +129,7 @@ describe("Crab Migration", function () {
             await expect(crabMigration.connect(d2).withdrawV1Shares(deposit2Amount.mul(2))).to.be.revertedWith("ds-math-sub-underflow");
         })
 
-        it("d2 deposits crabV1 shares", async () => { 
+        it("d2 withdraws 50% of crabV1 shares", async () => { 
             const crabV1BalanceBefore = await crabStrategyV1.balanceOf(crabMigration.address); 
 
             await crabMigration.connect(d2).withdrawV1Shares(deposit2Amount.div(2));

--- a/packages/hardhat/test/unit-tests/strategy/crab-migration.ts
+++ b/packages/hardhat/test/unit-tests/strategy/crab-migration.ts
@@ -125,6 +125,23 @@ describe("Crab Migration", function () {
             expect(d2SharesDeposited).to.be.equal(deposit2Amount);
         })
 
+        it("d2 withdraws more shares than they have deposited crabV1 shares", async () => { 
+            await expect(crabMigration.connect(d2).withdrawV1Shares(deposit2Amount.mul(2))).to.be.revertedWith("ds-math-sub-underflow");
+        })
+
+        it("d2 deposits crabV1 shares", async () => { 
+            const crabV1BalanceBefore = await crabStrategyV1.balanceOf(crabMigration.address); 
+
+            await crabMigration.connect(d2).withdrawV1Shares(deposit2Amount.div(2));
+
+            const crabV1BalanceAfter = await crabStrategyV1.balanceOf(crabMigration.address);
+            const d2SharesDeposited  = await crabMigration.sharesDeposited(d2.address);
+
+            expect(crabV1BalanceBefore.sub(crabV1BalanceAfter)).to.be.equal(deposit2Amount.div(2));
+            expect(d2SharesDeposited).to.be.equal(deposit2Amount.sub(deposit2Amount.div(2)));
+        })
+
+
         it("should not be able to claim until strategy has been migrated", async () => { 
             await expect(crabMigration.connect(d1).claimV2Shares()).to.be.revertedWith("M3");
         })


### PR DESCRIPTION
# Task: User crabV1 tokens can get stuck when the owner does not launch migrate

## Description
- add withdrawV1Shares function
- update unit tests
- update e2e tests