### PR TITLE
Token Balance Bug Fix

### DIFF
--- a/packages/frontend/src/hooks/contracts/useTokenBalance.ts
+++ b/packages/frontend/src/hooks/contracts/useTokenBalance.ts
@@ -49,7 +49,7 @@ export const useTokenBalance = (token: string, refetchIntervalSec = 30, decimals
   const prevBalance = usePrevious(balanceQuery.data?.toString())
 
   useEffect(() => {
-    if (poll && prevBalance !== balanceQuery.data?.toString()) {
+    if (poll && prevBalance && balanceQuery.data && prevBalance !== balanceQuery.data?.toString()) {
       setPoll(false)
     }
   }, [balanceQuery.data?.toString(), poll, prevBalance])


### PR DESCRIPTION
Before, long and short positions only conditionally showed up since oSQTH balance showed up as 0.
https://user-images.githubusercontent.com/29926727/180891654-89bb6c88-b286-410c-9810-e19110c93ded.mov

This was due to an issue where polling was wrongfully set to false, even when variables only differed since one was null.