### PR TITLE
Crab V2 Short Position Bug Fix

### DIFF
--- a/packages/frontend/src/queries/uniswap/__generated__/subscriptionSwaps.ts
+++ b/packages/frontend/src/queries/uniswap/__generated__/subscriptionSwaps.ts
@@ -52,5 +52,5 @@ export interface subscriptionSwapsVariables {
   tokenAddress: any;
   origin: any;
   orderDirection: string;
-  recipient_not: any;
+  recipient_not_in: any[];
 }

--- a/packages/frontend/src/queries/uniswap/__generated__/subscriptionSwapsRopsten.ts
+++ b/packages/frontend/src/queries/uniswap/__generated__/subscriptionSwapsRopsten.ts
@@ -53,5 +53,5 @@ export interface subscriptionSwapsRopstenVariables {
   recipients: string[];
   origin: any;
   orderDirection: string;
-  recipient_not: any;
+  recipient_not_in: any[];
 }

--- a/packages/frontend/src/queries/uniswap/__generated__/swaps.ts
+++ b/packages/frontend/src/queries/uniswap/__generated__/swaps.ts
@@ -52,5 +52,5 @@ export interface swapsVariables {
   tokenAddress: any;
   origin: any;
   orderDirection: string;
-  recipient_not: any;
+  recipient_not_in: any[];
 }

--- a/packages/frontend/src/queries/uniswap/__generated__/swapsRopsten.ts
+++ b/packages/frontend/src/queries/uniswap/__generated__/swapsRopsten.ts
@@ -53,5 +53,5 @@ export interface swapsRopstenVariables {
   recipients: string[];
   origin: any;
   orderDirection: string;
-  recipient_not: any;
+  recipient_not_in: any[];
 }

--- a/packages/frontend/src/queries/uniswap/swapsQuery.ts
+++ b/packages/frontend/src/queries/uniswap/swapsQuery.ts
@@ -5,12 +5,12 @@ export const SWAPS_SUBSCRIPTION = gql`
     $tokenAddress: Bytes!
     $origin: Bytes!
     $orderDirection: String!
-    $recipient_not: Bytes!
+    $recipient_not_in: [Bytes!]!
   ) {
     swaps(
       orderBy: timestamp
       orderDirection: $orderDirection
-      where: { token1: $tokenAddress, origin: $origin, recipient_not: $recipient_not }
+      where: { token1: $tokenAddress, origin: $origin, recipient_not_in: $recipient_not_in }
       first: 1000
       skip: 0
     ) {
@@ -40,11 +40,11 @@ export const SWAPS_SUBSCRIPTION = gql`
 `
 
 export const SWAPS_QUERY = gql`
-  query swaps($tokenAddress: Bytes!, $origin: Bytes!, $orderDirection: String!, $recipient_not: Bytes!) {
+  query swaps($tokenAddress: Bytes!, $origin: Bytes!, $orderDirection: String!, $recipient_not_in: [Bytes!]!) {
     swaps(
       orderBy: timestamp
       orderDirection: $orderDirection
-      where: { token1: $tokenAddress, origin: $origin, recipient_not: $recipient_not, poolAddress: $poolAddress }
+      where: { token1: $tokenAddress, origin: $origin, recipient_not_in: $recipient_not_in, poolAddress: $poolAddress }
       first: 1000
       skip: 0
     ) {

--- a/packages/frontend/src/queries/uniswap/swapsRopstenQuery.ts
+++ b/packages/frontend/src/queries/uniswap/swapsRopstenQuery.ts
@@ -6,12 +6,12 @@ export const SWAPS_ROPSTEN_SUBSCRIPTION = gql`
     $recipients: [String!]!
     $origin: Bytes!
     $orderDirection: String!
-    $recipient_not: Bytes!
+    $recipient_not_in: [Bytes!]!
   ) {
     swaps(
       orderBy: timestamp
       orderDirection: $orderDirection
-      where: { pool: $poolAddress, origin: $origin, recipient_in: $recipients, recipient_not: $recipient_not }
+      where: { pool: $poolAddress, origin: $origin, recipient_in: $recipients, recipient_not_in: $recipient_not_in }
       first: 1000
       skip: 0
     ) {
@@ -46,12 +46,12 @@ export const SWAPS_ROPSTEN_QUERY = gql`
     $recipients: [String!]!
     $origin: Bytes!
     $orderDirection: String!
-    $recipient_not: Bytes!
+    $recipient_not_in: [Bytes!]!
   ) {
     swaps(
       orderBy: timestamp
       orderDirection: $orderDirection
-      where: { pool: $poolAddress, origin: $origin, recipient_in: $recipients, recipient_not: $recipient_not }
+      where: { pool: $poolAddress, origin: $origin, recipient_in: $recipients, recipient_not_in: $recipient_not_in }
       first: 1000
       skip: 0
     ) {

--- a/packages/frontend/src/state/positions/hooks.ts
+++ b/packages/frontend/src/state/positions/hooks.ts
@@ -48,7 +48,7 @@ export const useSwaps = () => {
   const [networkId] = useAtom(networkIdAtom)
   const [address] = useAtom(addressAtom)
   const setSwaps = useUpdateAtom(swapsAtom)
-  const { squeethPool, oSqueeth, shortHelper, swapRouter, crabStrategy } = useAtomValue(addressesAtom)
+  const { squeethPool, oSqueeth, shortHelper, swapRouter, crabStrategy, crabStrategy2 } = useAtomValue(addressesAtom)
   const { subscribeToMore, data, refetch, loading, error, startPolling, stopPolling } = useQuery<
     swaps | swapsRopsten,
     swapsVariables | swapsRopstenVariables
@@ -56,7 +56,7 @@ export const useSwaps = () => {
     variables: {
       origin: address || '',
       orderDirection: 'asc',
-      recipient_not: crabStrategy,
+      recipient_not_in: [crabStrategy, crabStrategy2],
       ...(networkId === Networks.MAINNET
         ? {
             tokenAddress: oSqueeth,
@@ -75,7 +75,7 @@ export const useSwaps = () => {
       variables: {
         origin: address || '',
         orderDirection: 'asc',
-        recipient_not: crabStrategy,
+        recipient_not_in: [crabStrategy, crabStrategy2],
         ...(networkId === Networks.MAINNET
           ? {
               tokenAddress: oSqueeth,


### PR DESCRIPTION
# Task: Fix Positions Not to Show Crab Swaps as Short/Long Positions

## Description

Before: Depositing into crab showed up as a short position in the amount of the swap. This was because the GraphQL query which uses Uniswap's subgraph omitted swaps with the oSQTH-ETH pool that were called from the Crab V1 contract, but not the Crab V2 contract.

Now: The GraphQL query which uses Uniswap's subgraph omits swaps with the oSQTH-ETH pool that are called from **either** the Crab V1 **or** Crab V2 contract.

## Things to Test
- Open a crab position & make sure it does not show a short position
- Partial close crab position & make sure it does not show a short or long position
- Fully close crab position & make sure it does not show a 0 oSQTH long position
- Open/close a long position & make sure it just shows the proper long position
- Open/close a short position & make sure it just shows the proper short position
- Make sure no ghost vault

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update