### PR TITLE
WIP: Flashdeposit frontrun

### DIFF
--- a/packages/frontend/src/state/crab/hooks.ts
+++ b/packages/frontend/src/state/crab/hooks.ts
@@ -238,7 +238,7 @@ export const useCurrentCrabPositionValue = () => {
   }, [userCrabBalance])
 
   useAppEffect(() => {
-    ;(async () => {
+    ; (async () => {
       setIsCrabPositionValueLoading(true)
       const [collateral, squeethDebt] = await Promise.all([
         getCollateralFromCrabAmount(userShares, contract, vault),
@@ -301,7 +301,7 @@ export const useCurrentCrabPositionValueV2 = () => {
   }, [userMigratedShares, userCrabBalance])
 
   useAppEffect(() => {
-    ;(async () => {
+    ; (async () => {
       if (balLoading) {
         setIsCrabPositionValueLoading(true)
       }
@@ -497,6 +497,11 @@ export const useFlashDepositV2 = (calculateETHtoBorrowFromUniswap: any) => {
       if (!contract || !vault) return
 
       let { ethBorrow: _ethBorrow } = await calculateETHtoBorrowFromUniswap(amount, slippage)
+      // Just to make sure the issue never happens
+      if (_ethBorrow.isZero()) {
+        alert('Some error occurred. Refresh the page!')
+        throw new Error('Some error occurred. Refresh the page!')
+      }
       const _allowedEthToBorrow = maxCap.minus(amount.plus(vault.collateralAmount))
       if (_ethBorrow.gt(_allowedEthToBorrow)) {
         _ethBorrow = _allowedEthToBorrow

--- a/packages/frontend/src/state/squeethPool/hooks.ts
+++ b/packages/frontend/src/state/squeethPool/hooks.ts
@@ -104,6 +104,8 @@ export const useUpdateSqueethPoolData = () => {
         ticks || [],
       )
 
+      console.log("Pools is set with tick length", ticks?.length)
+
       setPool(pool)
       setWethToken(isWethToken0 ? TokenA : TokenB)
       setSqueethToken(isWethToken0 ? TokenB : TokenA)

--- a/packages/frontend/src/state/squeethPool/hooks.ts
+++ b/packages/frontend/src/state/squeethPool/hooks.ts
@@ -94,19 +94,17 @@ export const useUpdateSqueethPoolData = () => {
         isWethToken0 ? 'oSqueeth' : 'Wrapped Ether',
       )
 
-      if (ticks?.length) {
-        const pool = new Pool(
-          TokenA,
-          TokenB,
-          Number(fee),
-          state.sqrtPriceX96.toString(),
-          state.liquidity.toString(),
-          Number(state.tick),
-          ticks || [],
-        )
-  
-        setPool(pool)
-      }
+      const pool = new Pool(
+        TokenA,
+        TokenB,
+        Number(fee),
+        state.sqrtPriceX96.toString(),
+        state.liquidity.toString(),
+        Number(state.tick),
+        ticks || [],
+      )
+
+      setPool(pool)
       setWethToken(isWethToken0 ? TokenA : TokenB)
       setSqueethToken(isWethToken0 ? TokenB : TokenA)
     })()

--- a/packages/frontend/src/state/squeethPool/hooks.ts
+++ b/packages/frontend/src/state/squeethPool/hooks.ts
@@ -94,17 +94,19 @@ export const useUpdateSqueethPoolData = () => {
         isWethToken0 ? 'oSqueeth' : 'Wrapped Ether',
       )
 
-      const pool = new Pool(
-        TokenA,
-        TokenB,
-        Number(fee),
-        state.sqrtPriceX96.toString(),
-        state.liquidity.toString(),
-        Number(state.tick),
-        ticks || [],
-      )
-
-      setPool(pool)
+      if (ticks?.length) {
+        const pool = new Pool(
+          TokenA,
+          TokenB,
+          Number(fee),
+          state.sqrtPriceX96.toString(),
+          state.liquidity.toString(),
+          Number(state.tick),
+          ticks || [],
+        )
+  
+        setPool(pool)
+      }
       setWethToken(isWethToken0 ? TokenA : TokenB)
       setSqueethToken(isWethToken0 ? TokenB : TokenA)
     })()


### PR DESCRIPTION
- Sometimes `calculateETHtoBorrowFromUniswap` returns 0, because tick list length is 0 https://github.com/Uniswap/v3-sdk/blob/6e59ae3e893ae738767446c1e1d19a5c6a2c9588/src/utils/tickList.ts#L41
- In this fix I only initialize pool after getting the tick list data
- To make sure if this issue never happens, I am also showing an alert / throwing the error if ethToBorrow is 0