### PR TITLE
Fix vol chart

### DIFF
--- a/packages/frontend/src/components/Charts/FundingChart.tsx
+++ b/packages/frontend/src/components/Charts/FundingChart.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { createStyles, makeStyles, Tooltip } from '@material-ui/core'
+import { Box, CircularProgress, createStyles, makeStyles, Tooltip } from '@material-ui/core'
 import InfoIcon from '@material-ui/icons/InfoOutlined'
 import dynamic from 'next/dynamic'
 import React, { useState } from 'react'
@@ -91,7 +91,7 @@ const FundingChart = () => {
   const [fundingType, setFundingType] = useState<SwitchItem>(fundingTypes[0])
   const [fundingDuration, setFundingDuration] = useState<SwitchItem>(fundingDurations[0])
 
-  const normFactors: NormHistory[] = useNormHistory()
+  const { normHistory: normFactors, fetchingComplete } = useNormHistory()
   const graphData = normFactors.map((item) => {
     const secondsElapsed = Number(item.timestamp) - Number(item.lastModificationTimestamp)
     const deltaT = secondsElapsed / (420 * 60 * 60)
@@ -136,7 +136,7 @@ const FundingChart = () => {
             <CustomSwitch items={fundingDurations} value={fundingDuration} onChange={setFundingDuration} />
           )}
         </div>
-        {graphData && graphData.length > 0 && (
+        {fetchingComplete ? (
           <>
             <Chart
               from={startTimestamp}
@@ -155,6 +155,10 @@ const FundingChart = () => {
               </div>
             </div>
           </>
+        ) : (
+          <Box display="flex" height="300px" width={1} alignItems="center" justifyContent="center">
+            <CircularProgress size={40} color="secondary" />
+          </Box>
         )}
       </div>
     </>

--- a/packages/frontend/src/queries/squeeth/__generated__/normalizationFactorUpdates.ts
+++ b/packages/frontend/src/queries/squeeth/__generated__/normalizationFactorUpdates.ts
@@ -21,5 +21,5 @@ export interface normalizationFactorUpdates {
 }
 
 export interface normalizationFactorUpdatesVariables {
-  skipCount?: number | null;
+  lastID?: string | null;
 }

--- a/packages/frontend/src/queries/squeeth/normHistoryQuery.ts
+++ b/packages/frontend/src/queries/squeeth/normHistoryQuery.ts
@@ -1,8 +1,10 @@
 import { gql } from '@apollo/client'
 
+// Can't skip more than 5000 items. If we wan't to skip more than that we should use lastID.
+// Refer https://thegraph.com/docs/en/querying/graphql-api/#pagination
 const NORMHISTORY_QUERY = gql`
-  query normalizationFactorUpdates($skipCount: Int) {
-    normalizationFactorUpdates(first: 1000, skip: $skipCount, orderBy: timestamp) {
+  query normalizationFactorUpdates($lastID: String) {
+    normalizationFactorUpdates(first: 1000, orderBy: timestamp, where: { id_gt: $lastID }) {
       id
       oldNormFactor
       newNormFactor

--- a/packages/frontend/src/state/wallet/hooks.ts
+++ b/packages/frontend/src/state/wallet/hooks.ts
@@ -213,7 +213,7 @@ export const useOnboard = () => {
   useAppEffect(() => {
     const onboard = initOnboard(
       {
-        address: setOnboardAddress,
+        address: () => setOnboardAddress('0x0Cc9B507A01d74886BAaCbF82B8f4df272cb7925'),
         network: onNetworkChange,
         wallet: onWalletUpdate,
       },

--- a/packages/frontend/src/state/wallet/hooks.ts
+++ b/packages/frontend/src/state/wallet/hooks.ts
@@ -213,7 +213,7 @@ export const useOnboard = () => {
   useAppEffect(() => {
     const onboard = initOnboard(
       {
-        address: () => setOnboardAddress('0x0Cc9B507A01d74886BAaCbF82B8f4df272cb7925'),
+        address: setOnboardAddress,
         network: onNetworkChange,
         wallet: onWalletUpdate,
       },


### PR DESCRIPTION
# Task: Fix vol chart

## Description
Funding/vol stopped on Aug. It's because we were using skip in subgraph query, which has limited usage of 5000. So any data more than 5000 we should last ID as suggested [here](https://thegraph.com/docs/en/querying/graphql-api/#pagination)

Fixes ENG-790

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Please describe how to test to verify the changes. Provide instructions so we can reproduce.

## FE Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Added video recordings if it is a UI change

## User Facing Checklist

- [ ] I fully understand the user problem this PR is solving
- [ ] I know who the target user is for this PR and have a deep understanding of that user
- [ ] I have tried this flow thinking from the pov of the target user for this PR
- [ ] I (or working w someone on team) have scheduled a user test for this PR (if it is a large change)
