### PR TITLE
Feat/ Improve BullStrategy coverage

### DIFF
--- a/packages/bull-vault/src/BullStrategy.sol
+++ b/packages/bull-vault/src/BullStrategy.sol
@@ -106,7 +106,6 @@ contract BullStrategy is ERC20, LeverageBull {
      * @param _cap strategy cap
      */
     function setCap(uint256 _cap) external onlyOwner {
-
         emit SetCap(strategyCap, _cap);
 
         strategyCap = _cap;

--- a/packages/bull-vault/src/BullStrategy.sol
+++ b/packages/bull-vault/src/BullStrategy.sol
@@ -18,8 +18,7 @@ import { VaultLib } from "squeeth-monorepo/libs/VaultLib.sol";
 
 /**
  * Error codes
- * BS0: Can't receive ETH from this sender
- * BS1: Invalid strategy cap
+ * BS1: Can't receive ETH from this sender
  * BS2: Strategy cap reached max
  * BS3: redeemShortShutdown must be called first
  * BS4: emergency shutdown contract needs to initiate the shutdownRepayAndWithdraw call
@@ -83,7 +82,7 @@ contract BullStrategy is ERC20, LeverageBull {
     }
 
     receive() external payable {
-        require(msg.sender == weth || msg.sender == address(crab), "BS0");
+        require(msg.sender == weth || msg.sender == address(crab), "BS1");
     }
 
     /**
@@ -104,10 +103,9 @@ contract BullStrategy is ERC20, LeverageBull {
 
     /**
      * @notice set strategy cap
-     * @param _cap startegy cap
+     * @param _cap strategy cap
      */
     function setCap(uint256 _cap) external onlyOwner {
-        require(_cap != 0, "BS1");
 
         emit SetCap(strategyCap, _cap);
 

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -118,6 +118,25 @@ contract BullStrategyTestFork is Test {
         assertTrue(emergencyShutdown.bullStrategy() == address(bullStrategy));
     }
 
+    function testSetCap() public {
+        cap = 0;
+        vm.startPrank(bullOwner);
+        bullStrategy.setCap(cap);
+        assertEq(bullStrategy.strategyCap(),cap);
+    }
+
+    function testRedeemCrabAndWithdrawWEthWhenCallerNotOwner() public {
+        vm.startPrank(deployer);
+        vm.expectRevert(bytes("BS8"));
+        bullStrategy.redeemCrabAndWithdrawWEth(0,0);
+    }
+
+    function testDepositEthIntoCrabWhenCallerNotOwner() public {
+        vm.startPrank(deployer);
+        vm.expectRevert(bytes("BS8"));
+        bullStrategy.depositEthIntoCrab(0);
+    }
+
     function testSetCapWhenCallerNotOwner() public {
         cap = 1000000e18;
         vm.startPrank(deployer);
@@ -267,7 +286,7 @@ contract BullStrategyTestFork is Test {
         (bool status, bytes memory returndata) = address(bullStrategy).call{value: 5e18}("");
         vm.stopPrank();
         assertFalse(status);
-        assertEq(_getRevertMsg(returndata), "BS0");
+        assertEq(_getRevertMsg(returndata), "BS1");
     }
 
     function testSendLessEthComparedToCrabAmount() public {

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -222,9 +222,8 @@ contract BullStrategyTestFork is Test {
                 IEulerEToken(eToken).balanceOfUnderlying(address(bullStrategy)).sub(wethToLend)
             ) <= 1
         );
-        
-        assertEq(IERC20(usdc).balanceOf(user1).sub(usdcToBorrowSecond), userUsdcBalanceBefore);
 
+        assertEq(IERC20(usdc).balanceOf(user1).sub(usdcToBorrowSecond), userUsdcBalanceBefore);
     }
 
     function testWithdraw() public {
@@ -289,8 +288,6 @@ contract BullStrategyTestFork is Test {
             crabV2.balanceOf(address(bullStrategy)),
             "Bull crab balance mismatch"
         );
-
-
     }
 
     function testReceiveFromNonWethOrCrab() public {

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -122,13 +122,13 @@ contract BullStrategyTestFork is Test {
         cap = 0;
         vm.startPrank(bullOwner);
         bullStrategy.setCap(cap);
-        assertEq(bullStrategy.strategyCap(),cap);
+        assertEq(bullStrategy.strategyCap(), cap);
     }
 
     function testRedeemCrabAndWithdrawWEthWhenCallerNotOwner() public {
         vm.startPrank(deployer);
         vm.expectRevert(bytes("BS8"));
-        bullStrategy.redeemCrabAndWithdrawWEth(0,0);
+        bullStrategy.redeemCrabAndWithdrawWEth(0, 0);
     }
 
     function testDepositEthIntoCrabWhenCallerNotOwner() public {

--- a/packages/bull-vault/test/integration-test/FlashBullTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/FlashBullTestFork.t.sol
@@ -40,7 +40,6 @@ contract FlashBullTestFork is Test {
     Controller internal controller;
     Quoter internal quoter;
 
-
     address internal weth;
     address internal usdc;
     address internal euler;
@@ -790,10 +789,12 @@ contract FlashBullTestFork is Test {
         uint256 usdcToBorrow,
         uint256 wSqueethToMint
     ) internal returns (uint256) {
-        uint256 minEthFromSqueeth = quoter.quoteExactInputSingle(wPowerPerp, weth, 3000, wSqueethToMint, 0);
+        uint256 minEthFromSqueeth =
+            quoter.quoteExactInputSingle(wPowerPerp, weth, 3000, wSqueethToMint, 0);
         uint256 minEthFromUsdc = quoter.quoteExactInputSingle(usdc, weth, 3000, usdcToBorrow, 0);
 
-        uint256 totalEthToBull = wethToLend.add(ethToCrab).sub(minEthFromSqueeth).sub(minEthFromUsdc).add(10e16);
+        uint256 totalEthToBull =
+            wethToLend.add(ethToCrab).sub(minEthFromSqueeth).sub(minEthFromUsdc).add(10e16);
         return totalEthToBull;
     }
 


### PR DESCRIPTION
# Task:  Improve BullStrategy coverage with some missing tests

## Description
- call redeemCrabAndWithdrawWEth() with non-auction address, revert - Fixes ENG-868
- call depositEthIntoCrab() with non-auction address, revert  - Fixes ENG-869
- remove setCap 0 size restriction  - Fixes ENG-870
- tests successful cap set (assert correct value set)

Fixes ENG-867

PR coverage:
![Screen Shot 2022-11-12 at 12 48 38 PM](https://user-images.githubusercontent.com/5490766/201494224-82d9043a-e822-4d8f-a6da-5cff3d5cc179.png)

Main coverage:
![Screen Shot 2022-11-12 at 12 55 39 PM](https://user-images.githubusercontent.com/5490766/201494219-81cc507b-c358-4d48-a3eb-3ae14ef28a7f.png)
