### PR TITLE
Feat / Improve LeverageBull tests / coverage

### DIFF
--- a/packages/bull-vault/src/LeverageBull.sol
+++ b/packages/bull-vault/src/LeverageBull.sol
@@ -18,6 +18,7 @@ import { UniOracle } from "./UniOracle.sol";
  * Error codes
  * LB0: ETH sent is not equal to ETH to deposit in Euler
  * LB1: caller is not auction address
+ * LB2: auction can not be set to 0 address
  */
 
 /**
@@ -93,7 +94,7 @@ contract LeverageBull is Ownable {
     }
 
     function setAuction(address _auction) external onlyOwner {
-        require(_auction != address(0), "BS3");
+        require(_auction != address(0), "LB2");
 
         emit SetAuction(auction, _auction);
 
@@ -185,7 +186,7 @@ contract LeverageBull is Ownable {
 
         require(wethToLend == _ethAmount, "LB0");
 
-        _depositWethInEuler(wethToLend, true);
+        _depositWethInEuler(wethToLend);
         _borrowUsdcFromEuler(usdcToBorrow);
 
         return (wethToLend, usdcToBorrow, IEulerEToken(eToken).balanceOfUnderlying(address(this)));
@@ -194,10 +195,9 @@ contract LeverageBull is Ownable {
     /**
      * @dev deposit weth as collateral in Euler market
      * @param _ethToDeposit amount of ETH to deposit
-     * @param _wrapEth wrap ETH to WETH if true
      */
-    function _depositWethInEuler(uint256 _ethToDeposit, bool _wrapEth) internal {
-        if (_wrapEth) IWETH9(weth).deposit{value: _ethToDeposit}();
+    function _depositWethInEuler(uint256 _ethToDeposit) internal {
+        IWETH9(weth).deposit{value: _ethToDeposit}();
         IEulerEToken(eToken).deposit(0, _ethToDeposit);
         IEulerMarkets(eulerMarkets).enterMarket(0, weth);
     }
@@ -275,9 +275,5 @@ contract LeverageBull is Ownable {
      */
     function _calcUsdcToRepay(uint256 _bullShare) internal view returns (uint256) {
         return _bullShare.wmul(IEulerDToken(dToken).balanceOf(address(this)));
-    }
-
-    function _isAuction() internal view returns (bool) {
-        return msg.sender == auction;
     }
 }

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -233,9 +233,8 @@ contract BullStrategyTestFork is Test {
                 IEulerEToken(eToken).balanceOfUnderlying(address(bullStrategy)).sub(wethToLend)
             ) <= 1
         );
-        
-        assertEq(IERC20(usdc).balanceOf(user1).sub(usdcToBorrowSecond), userUsdcBalanceBefore);
 
+        assertEq(IERC20(usdc).balanceOf(user1).sub(usdcToBorrowSecond), userUsdcBalanceBefore);
     }
 
     function testWithdraw() public {
@@ -300,8 +299,6 @@ contract BullStrategyTestFork is Test {
             crabV2.balanceOf(address(bullStrategy)),
             "Bull crab balance mismatch"
         );
-
-
     }
 
     function testReceiveFromNonWethOrCrab() public {

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -151,7 +151,7 @@ contract BullStrategyTestFork is Test {
         vm.expectRevert(bytes("LB1"));
         bullStrategy.depositAndBorrowFromLeverage(0, 0);
     }
-    
+
     function testSetCap() public {
         cap = 0;
         vm.startPrank(bullOwner);

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -118,6 +118,36 @@ contract BullStrategyTestFork is Test {
         assertTrue(emergencyShutdown.bullStrategy() == address(bullStrategy));
     }
 
+    function testSetAuctionZeroAddress() public {
+        vm.prank(bullOwner);
+        vm.expectRevert(bytes("LB2"));
+        bullStrategy.setAuction(address(0));
+    }
+
+    function testSetAuctionWhenCallerNotOwner() public {
+        vm.prank(user1);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        bullStrategy.setAuction(address(1));
+    }
+
+    function testSetAuction() public {
+        vm.prank(bullOwner);
+        bullStrategy.setAuction(address(1));
+        assertEq(bullStrategy.auction(), address(1));
+    }
+
+    function testAuctionRepayAndWithdrawFromLeverageWhenCallerNotAuction() public {
+        vm.prank(bullOwner);
+        vm.expectRevert(bytes("LB1"));
+        bullStrategy.auctionRepayAndWithdrawFromLeverage(0, 0);
+    }
+
+    function testdepositAndBorrowFromLeverageWhenCallerNotAuction() public {
+        vm.prank(bullOwner);
+        vm.expectRevert(bytes("LB1"));
+        bullStrategy.depositAndBorrowFromLeverage(0, 0);
+    }
+
     function testSetCapWhenCallerNotOwner() public {
         cap = 1000000e18;
         vm.startPrank(deployer);

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -150,7 +150,8 @@ contract BullStrategyTestFork is Test {
         vm.prank(bullOwner);
         vm.expectRevert(bytes("LB1"));
         bullStrategy.depositAndBorrowFromLeverage(0, 0);
-
+    }
+    
     function testSetCap() public {
         cap = 0;
         vm.startPrank(bullOwner);

--- a/packages/bull-vault/test/integration-test/FlashBullTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/FlashBullTestFork.t.sol
@@ -40,7 +40,6 @@ contract FlashBullTestFork is Test {
     Controller internal controller;
     Quoter internal quoter;
 
-
     address internal weth;
     address internal usdc;
     address internal euler;
@@ -790,10 +789,12 @@ contract FlashBullTestFork is Test {
         uint256 usdcToBorrow,
         uint256 wSqueethToMint
     ) internal returns (uint256) {
-        uint256 minEthFromSqueeth = quoter.quoteExactInputSingle(wPowerPerp, weth, 3000, wSqueethToMint, 0);
+        uint256 minEthFromSqueeth =
+            quoter.quoteExactInputSingle(wPowerPerp, weth, 3000, wSqueethToMint, 0);
         uint256 minEthFromUsdc = quoter.quoteExactInputSingle(usdc, weth, 3000, usdcToBorrow, 0);
 
-        uint256 totalEthToBull = wethToLend.add(ethToCrab).sub(minEthFromSqueeth).sub(minEthFromUsdc).add(10e16);
+        uint256 totalEthToBull =
+            wethToLend.add(ethToCrab).sub(minEthFromSqueeth).sub(minEthFromUsdc).add(10e16);
         return totalEthToBull;
     }
 


### PR DESCRIPTION
# Task:Improve LeverageBull tests/coverage

## Description
- setAuction revert if address(0) - Fixes ENG-850
- setAuction revert if not owner - Fixes ENG-851
- setAuction successfully set auction address  - Fixes ENG-852
- auctionRepayAndWithdrawFromLeverage() revert with non auction caller - Fixes ENG-853
- depositAndBorrowFromLeverage() revert with non auction caller - Fixes ENG-854
- remove the if statement in _depositWethInEuler for _wrapEth - Fixes ENG-855
- delete _isAuction() in LeverageBull - Fixes ENG-856
- fixes incorrect error code for address(0) input in setAuction()

Fixes ENG-849

PR Coverage:
![Screen Shot 2022-11-12 at 1 25 34 PM](https://user-images.githubusercontent.com/5490766/201495472-e19890b2-0b04-4274-8faf-87f8dd9e9801.png)

Main Coverage:
![Screen Shot 2022-11-12 at 12 55 39 PM](https://user-images.githubusercontent.com/5490766/201495483-cd9e629d-b96a-4107-93a1-1c18d8cefd1c.png)
