### PR TITLE
Feat/ FlashDeposit gas optimization

### DIFF
--- a/packages/bull-vault/src/FlashBull.sol
+++ b/packages/bull-vault/src/FlashBull.sol
@@ -129,10 +129,8 @@ contract FlashBull is UniFlash {
             (ethInCrab, squeethInCrab) = IBullStrategy(bullStrategy).getCrabVaultDetails();
 
             uint256 ethFee;
-            uint256 squeethEthPrice =
-                UniOracle._getTwap(ethWSqueethPool, wPowerPerp, weth, TWAP, false);
             (wSqueethToMint, ethFee) = _calcWsqueethToMintAndFee(
-                _params.ethToCrab, squeethInCrab, ethInCrab, squeethEthPrice
+                _params.ethToCrab, squeethInCrab, ethInCrab
             );
             crabAmount = _calcSharesToMint(
                 _params.ethToCrab.sub(ethFee), ethInCrab, IERC20(crab).totalSupply()
@@ -286,17 +284,22 @@ contract FlashBull is UniFlash {
     function _calcWsqueethToMintAndFee(
         uint256 _depositedEthAmount,
         uint256 _strategyDebtAmount,
-        uint256 _strategyCollateralAmount,
-        uint256 _squeethEthPrice
+        uint256 _strategyCollateralAmount
     ) internal view returns (uint256, uint256) {
         uint256 feeRate = IController(IBullStrategy(bullStrategy).powerTokenController()).feeRate();
-        uint256 feeAdjustment = _squeethEthPrice.mul(feeRate).div(10000);
-        uint256 wSqueethToMint = _depositedEthAmount.wmul(_strategyDebtAmount).wdiv(
+        if (feeRate != 0) {
+            uint256 squeethEthPrice =
+                UniOracle._getTwap(ethWSqueethPool, wPowerPerp, weth, TWAP, false);
+            uint256 feeAdjustment = squeethEthPrice.mul(feeRate).div(10000);
+            uint256 wSqueethToMint = _depositedEthAmount.wmul(_strategyDebtAmount).wdiv(
             _strategyCollateralAmount.add(_strategyDebtAmount.wmul(feeAdjustment))
-        );
-        uint256 fee = wSqueethToMint.wmul(feeAdjustment);
-
-        return (wSqueethToMint, fee);
+            );
+            uint256 fee = wSqueethToMint.wmul(feeAdjustment);
+            return (wSqueethToMint, fee);
+        }
+        uint256 wSqueethToMint = _depositedEthAmount.wmul(_strategyDebtAmount).wdiv(
+        _strategyCollateralAmount);
+        return (wSqueethToMint, 0);
     }
 
     /**

--- a/packages/bull-vault/src/FlashBull.sol
+++ b/packages/bull-vault/src/FlashBull.sol
@@ -16,6 +16,7 @@ import { UniFlash } from "./UniFlash.sol";
 import { StrategyMath } from "squeeth-monorepo/strategy/base/StrategyMath.sol"; // StrategyMath licensed under AGPL-3.0-only
 import { Address } from "openzeppelin/utils/Address.sol";
 import { UniOracle } from "./UniOracle.sol";
+import { VaultLib } from "squeeth-monorepo/libs/VaultLib.sol";
 
 /**
  * @notice FlashBull contract
@@ -52,6 +53,8 @@ contract FlashBull is UniFlash {
     address private immutable ethUSDCPool;
     /// @dev bull stratgey address
     address public immutable bullStrategy;
+    /// @dev power perp controller address
+    address private immutable powerTokenController;
 
     /// @dev data structs from Uni v3 callback
     struct FlashDepositCrabData {
@@ -100,6 +103,7 @@ contract FlashBull is UniFlash {
     constructor(address _bull, address _factory) UniFlash(_factory) {
         bullStrategy = _bull;
         crab = IBullStrategy(_bull).crab();
+        powerTokenController = IBullStrategy(_bull).powerTokenController();
         wPowerPerp = IController(IBullStrategy(_bull).powerTokenController()).wPowerPerp();
         weth = IController(IBullStrategy(_bull).powerTokenController()).weth();
         usdc = IController(IBullStrategy(_bull).powerTokenController()).quoteCurrency();
@@ -126,12 +130,11 @@ contract FlashBull is UniFlash {
         uint256 ethInCrab;
         uint256 squeethInCrab;
         {
-            (ethInCrab, squeethInCrab) = IBullStrategy(bullStrategy).getCrabVaultDetails();
+            (ethInCrab, squeethInCrab) = _getCrabVaultDetails();
 
             uint256 ethFee;
-            (wSqueethToMint, ethFee) = _calcWsqueethToMintAndFee(
-                _params.ethToCrab, squeethInCrab, ethInCrab
-            );
+            (wSqueethToMint, ethFee) =
+                _calcWsqueethToMintAndFee(_params.ethToCrab, squeethInCrab, ethInCrab);
             crabAmount = _calcSharesToMint(
                 _params.ethToCrab.sub(ethFee), ethInCrab, IERC20(crab).totalSupply()
             );
@@ -148,7 +151,7 @@ contract FlashBull is UniFlash {
             abi.encodePacked(_params.ethToCrab)
         );
 
-        (ethInCrab, squeethInCrab) = IBullStrategy(bullStrategy).getCrabVaultDetails();
+        (ethInCrab, squeethInCrab) = _getCrabVaultDetails();
         uint256 share;
         if (IERC20(bullStrategy).totalSupply() == 0) {
             share = ONE;
@@ -188,9 +191,8 @@ contract FlashBull is UniFlash {
         {
             uint256 bullShare = _params.bullAmount.wdiv(IERC20(bullStrategy).totalSupply());
             crabToRedeem = bullShare.wmul(IBullStrategy(bullStrategy).getCrabBalance());
-            (, uint256 squeethInCrab) = IBullStrategy(bullStrategy).getCrabVaultDetails();
-            uint256 crabTotalSupply = IERC20(crab).totalSupply();
-            wPowerPerpToRedeem = crabToRedeem.wmul(squeethInCrab).wdiv(crabTotalSupply);
+            (, uint256 squeethInCrab) = _getCrabVaultDetails();
+            wPowerPerpToRedeem = crabToRedeem.wmul(squeethInCrab).wdiv(IERC20(crab).totalSupply());
             usdcToRepay = IBullStrategy(bullStrategy).calcUsdcToRepay(bullShare);
         }
 
@@ -286,19 +288,19 @@ contract FlashBull is UniFlash {
         uint256 _strategyDebtAmount,
         uint256 _strategyCollateralAmount
     ) internal view returns (uint256, uint256) {
-        uint256 feeRate = IController(IBullStrategy(bullStrategy).powerTokenController()).feeRate();
+        uint256 feeRate = IController(powerTokenController).feeRate();
         if (feeRate != 0) {
             uint256 squeethEthPrice =
                 UniOracle._getTwap(ethWSqueethPool, wPowerPerp, weth, TWAP, false);
             uint256 feeAdjustment = squeethEthPrice.mul(feeRate).div(10000);
             uint256 wSqueethToMint = _depositedEthAmount.wmul(_strategyDebtAmount).wdiv(
-            _strategyCollateralAmount.add(_strategyDebtAmount.wmul(feeAdjustment))
+                _strategyCollateralAmount.add(_strategyDebtAmount.wmul(feeAdjustment))
             );
             uint256 fee = wSqueethToMint.wmul(feeAdjustment);
             return (wSqueethToMint, fee);
         }
-        uint256 wSqueethToMint = _depositedEthAmount.wmul(_strategyDebtAmount).wdiv(
-        _strategyCollateralAmount);
+        uint256 wSqueethToMint =
+            _depositedEthAmount.wmul(_strategyDebtAmount).wdiv(_strategyCollateralAmount);
         return (wSqueethToMint, 0);
     }
 
@@ -321,5 +323,12 @@ contract FlashBull is UniFlash {
         }
 
         return _amount;
+    }
+
+    function _getCrabVaultDetails() internal view returns (uint256, uint256) {
+        VaultLib.Vault memory strategyVault =
+            IController(powerTokenController).vaults(ICrabStrategyV2(crab).vaultId());
+
+        return (strategyVault.collateralAmount, strategyVault.shortAmount);
     }
 }

--- a/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/BullStrategyTestFork.t.sol
@@ -203,9 +203,8 @@ contract BullStrategyTestFork is Test {
                 IEulerEToken(eToken).balanceOfUnderlying(address(bullStrategy)).sub(wethToLend)
             ) <= 1
         );
-        
-        assertEq(IERC20(usdc).balanceOf(user1).sub(usdcToBorrowSecond), userUsdcBalanceBefore);
 
+        assertEq(IERC20(usdc).balanceOf(user1).sub(usdcToBorrowSecond), userUsdcBalanceBefore);
     }
 
     function testWithdraw() public {
@@ -270,8 +269,6 @@ contract BullStrategyTestFork is Test {
             crabV2.balanceOf(address(bullStrategy)),
             "Bull crab balance mismatch"
         );
-
-
     }
 
     function testReceiveFromNonWethOrCrab() public {

--- a/packages/bull-vault/test/integration-test/FlashBullTestFork.t.sol
+++ b/packages/bull-vault/test/integration-test/FlashBullTestFork.t.sol
@@ -40,7 +40,6 @@ contract FlashBullTestFork is Test {
     Controller internal controller;
     Quoter internal quoter;
 
-
     address internal weth;
     address internal usdc;
     address internal euler;
@@ -790,10 +789,12 @@ contract FlashBullTestFork is Test {
         uint256 usdcToBorrow,
         uint256 wSqueethToMint
     ) internal returns (uint256) {
-        uint256 minEthFromSqueeth = quoter.quoteExactInputSingle(wPowerPerp, weth, 3000, wSqueethToMint, 0);
+        uint256 minEthFromSqueeth =
+            quoter.quoteExactInputSingle(wPowerPerp, weth, 3000, wSqueethToMint, 0);
         uint256 minEthFromUsdc = quoter.quoteExactInputSingle(usdc, weth, 3000, usdcToBorrow, 0);
 
-        uint256 totalEthToBull = wethToLend.add(ethToCrab).sub(minEthFromSqueeth).sub(minEthFromUsdc).add(10e16);
+        uint256 totalEthToBull =
+            wethToLend.add(ethToCrab).sub(minEthFromSqueeth).sub(minEthFromUsdc).add(10e16);
         return totalEthToBull;
     }
 


### PR DESCRIPTION
# Task: Small refactors to FlashBull to reduce external calls and gas costs

## Description
- implement local _getCrabVaultDetails() instead of calling BullStrategy
- refactor _calcWsqueethToMintAndFee() to only call twap when needed
- local variable of powerTokenController instead of calling BullStrategy for it

Fixes ENG-892

Gas PR:
![Screen Shot 2022-11-12 at 2 48 59 PM](https://user-images.githubusercontent.com/5490766/201497683-2fb0fcdd-d67c-49f7-9ced-cfb29db055e6.png)

Gas Main:
![Screen Shot 2022-11-12 at 2 07 26 PM](https://user-images.githubusercontent.com/5490766/201497684-d573c7fa-b9e6-4988-9d51-dc5e99a5ea42.png)
