### PR TITLE
ui: add squeeth info (vol, ref vol etc.) and historical days adjustment to long squeeth mobile 

### DIFF
--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -490,7 +490,8 @@ const SqueethInfo: React.FC = () => {
         {/* hard coded width layout to align with the prev line */}
 
         {showAdvanced ? (
-          <><div className={classes.squeethInfoSubGroup}>
+          <>
+            <div className={classes.squeethInfoSubGroup}>
               <div className={classes.infoItem}>
                 <div className={classes.infoLabel}>
                   <Typography color="textSecondary" variant="body2">
@@ -533,15 +534,15 @@ const SqueethInfo: React.FC = () => {
                     <InfoIcon fontSize="small" className={classes.infoIcon} />
                   </Tooltip>
                 </div>
-                <Typography>{(osqthRefVol).toFixed(2)}%
+                <Typography>
+                  {osqthRefVol.toFixed(2)}%
                   <a target="_blank" href={squeethRefVolDocLink} rel="noreferrer">
                     <OpenInNew fontSize="small" className={classes.infoIcon} />
                   </a>
                 </Typography>
-                
               </div>
-          </div>
-          <div className={classes.squeethInfoSubGroup}>
+            </div>
+            <div className={classes.squeethInfoSubGroup}>
               <div className={classes.infoItem}>
                 <div className={classes.infoLabel}>
                   <Typography color="textSecondary" variant="body2">
@@ -553,7 +554,8 @@ const SqueethInfo: React.FC = () => {
                 </div>
                 <Typography>{normFactor.toFixed(4)}</Typography>
               </div>
-          </div></>
+            </div>
+          </>
         ) : null}
         <div className={classes.squeethInfoSubGroup}>
           <button className={classes.advancedDetails} onClick={toggleAdvanced}>
@@ -617,6 +619,9 @@ function TradePage() {
       <Hidden mdUp>
         <div className={classes.mobileContainer}>
           <Header />
+          <div className={classes.positionContainer}>
+            <SqueethInfo />
+          </div>
           <div className={classes.mobileSpacer}>
             {tradeType === TradeType.LONG ? (
               <LongChart />

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -165,8 +165,8 @@ const useStyles = makeStyles((theme) =>
     },
     squeethInfoSubGroup: {
       display: 'grid',
-      gap: theme.spacing(1),
-      gridTemplateColumns: 'repeat(auto-fit, minmax(5rem, 1fr))',
+      gap: theme.spacing(2),
+      gridTemplateColumns: 'repeat(auto-fit, minmax(8rem, 1fr))',
       marginBottom: theme.spacing(2),
       position: 'relative',
     },

--- a/packages/frontend/pages/strategies.tsx
+++ b/packages/frontend/pages/strategies.tsx
@@ -213,9 +213,9 @@ const Strategies: React.FC = () => {
   }, [collatRatio, displayCrabV1, setStrategyDataV2])
 
   useMemo(() => {
-    if (selectedIdx === 0) return Vaults.ETHBull
+    if (selectedIdx === 0) return Vaults.ETHBear
     if (selectedIdx === 1) return Vaults.CrabVault
-    if (selectedIdx === 2) return Vaults.ETHBear
+    if (selectedIdx === 2) return Vaults.ETHBull
     else return Vaults.Custom
   }, [selectedIdx])
 
@@ -241,18 +241,18 @@ const Strategies: React.FC = () => {
           }}
           aria-label="disabled tabs example"
         >
-          <Tab style={{ textTransform: 'none' }} label={Vaults.ETHBull} icon={<div>🐂</div>} />
-          <Tab style={{ textTransform: 'none' }} label={Vaults.CrabVault} icon={<div>🦀</div>} />
           <Tab style={{ textTransform: 'none' }} label={Vaults.ETHBear} icon={<div>🐻</div>} />
+          <Tab style={{ textTransform: 'none' }} label={Vaults.CrabVault} icon={<div>🦀</div>} />
+          <Tab style={{ textTransform: 'none' }} label={Vaults.ETHBull} icon={<div>🐂</div>} />
         </Tabs>
-        {selectedIdx === 0 ? ( //bull vault
+        {selectedIdx === 2 ? ( //bull vault
           <div className={classes.comingSoon}>
             <Image src={bull} alt="squeeth token" width={200} height={130} />
             <Typography variant="h6" style={{ marginLeft: '8px' }} color="primary">
               Coming soon
             </Typography>
           </div>
-        ) : selectedIdx === 2 ? ( //bear vault
+        ) : selectedIdx === 0 ? ( //bear vault
           <div className={classes.comingSoon}>
             <Image src={bear} alt="squeeth token" width={200} height={130} />
             <Typography variant="h6" style={{ marginLeft: '8px' }} color="primary">

--- a/packages/frontend/src/components/Charts/LongChart.tsx
+++ b/packages/frontend/src/components/Charts/LongChart.tsx
@@ -90,6 +90,20 @@ const useStyles = makeStyles((theme) =>
       marginTop: '10px',
       justifyContent: 'center',
     },
+    daysInput: {
+      width: '150px',
+      marginLeft: theme.spacing(2),
+      [theme.breakpoints.down('sm')]: {
+        width: 'auto',
+        marginLeft: theme.spacing(1.5),
+      },
+    },
+    daysInputLabel: {
+      fontSize: '1rem',
+      [theme.breakpoints.down('sm')]: {
+        fontSize: '0.9rem',
+      },
+    },
   }),
 )
 
@@ -203,9 +217,10 @@ function LongChart() {
             size="small"
             value={days}
             type="number"
-            style={{ width: 150, marginLeft: '16px' }}
+            className={classes.daysInput}
             label="Historical Days"
             variant="outlined"
+            InputLabelProps={{ className: classes.daysInputLabel }}
             // InputProps={{
             //   endAdornment: (
             //     <InputAdornment position="end">

--- a/packages/frontend/src/components/Charts/LongChart.tsx
+++ b/packages/frontend/src/components/Charts/LongChart.tsx
@@ -187,7 +187,7 @@ function LongChart() {
           scrollButtons="auto"
           variant="scrollable"
         >
-          <SqueethTab label={`Historical ${days}D PNL Simulation`} />
+          <SqueethTab label={`Historical ${days}D PNL`} />
           {/* <SqueethTab label="Price" /> */}
           {/* <SqueethTab label="Funding" /> */}
           <SqueethTab label="Payoff" />
@@ -196,30 +196,30 @@ function LongChart() {
           <SqueethTab label="Premium" />
           <SqueethTab label="Risks" />
         </SqueethTabs>
-        <Hidden smDown>
-          {mode === ChartType.PNL ? (
-            <TextField
-              onChange={(event) => setDays(parseInt(event.target.value))}
-              size="small"
-              value={days}
-              type="number"
-              style={{ width: 150, marginLeft: '16px' }}
-              label="Historical Days"
-              variant="outlined"
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <a href={Links.BacktestFAQ} target="_blank" rel="noreferrer">
-                      <Tooltip title={Tooltips.BacktestDisclaimer}>
-                        <InfoIcon fontSize="small" />
-                      </Tooltip>
-                    </a>
-                  </InputAdornment>
-                ),
-              }}
-            />
-          ) : null}
-        </Hidden>
+        {/* <Hidden smDown> */}
+        {mode === ChartType.PNL ? (
+          <TextField
+            onChange={(event) => setDays(parseInt(event.target.value))}
+            size="small"
+            value={days}
+            type="number"
+            style={{ width: 150, marginLeft: '16px' }}
+            label="Historical Days"
+            variant="outlined"
+            // InputProps={{
+            //   endAdornment: (
+            //     <InputAdornment position="end">
+            //       <a href={Links.BacktestFAQ} target="_blank" rel="noreferrer">
+            //         <Tooltip title={Tooltips.BacktestDisclaimer}>
+            //           <InfoIcon fontSize="small" />
+            //         </Tooltip>
+            //       </a>
+            //     </InputAdornment>
+            //   ),
+            // }}
+          />
+        ) : null}
+        {/* </Hidden> */}
       </div>
 
       {mode === ChartType.Payoff ? (


### PR DESCRIPTION
# Task: Add squeeth info (vol, ref vol etc.) and historical days adjustment to long squeeth mobile 

## Description

Previously couldn't see squeeth info (iv, ref vol etc.) or change the historical days for long squeeth PnL on mobile. This allows users to do that on mobile. 

<img width="299" alt="Screen Shot 2022-11-15 at 8 41 50 PM" src="https://user-images.githubusercontent.com/13340486/202085660-94bc4546-b99f-4551-81ff-7f9965fd60bf.png">

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update

## How Has This Been Tested

Tested locally

## FE Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Added video recordings if it is a UI change

## User Facing Checklist

- [x] I fully understand the user problem this PR is solving
- [x] I know who the target user is for this PR and have a deep understanding of that user
- [x] I have tried this flow thinking from the pov of the target user for this PR
- [ ] I (or working w someone on team) have scheduled a user test for this PR (if it is a large change)
