### PR TITLE
style improvements for small screens

### DIFF
--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -165,8 +165,8 @@ const useStyles = makeStyles((theme) =>
     },
     squeethInfoSubGroup: {
       display: 'grid',
-      gap: theme.spacing(1),
-      gridTemplateColumns: 'repeat(auto-fit, minmax(5rem, 1fr))',
+      gap: theme.spacing(2),
+      gridTemplateColumns: 'repeat(auto-fit, minmax(8rem, 1fr))',
       marginBottom: theme.spacing(2),
       position: 'relative',
     },

--- a/packages/frontend/src/components/Charts/LongChart.tsx
+++ b/packages/frontend/src/components/Charts/LongChart.tsx
@@ -90,6 +90,20 @@ const useStyles = makeStyles((theme) =>
       marginTop: '10px',
       justifyContent: 'center',
     },
+    daysInput: {
+      width: '150px',
+      marginLeft: theme.spacing(2),
+      [theme.breakpoints.down('sm')]: {
+        width: 'auto',
+        marginLeft: theme.spacing(1.5),
+      },
+    },
+    daysInputLabel: {
+      fontSize: '1rem',
+      [theme.breakpoints.down('sm')]: {
+        fontSize: '0.9rem',
+      },
+    },
   }),
 )
 
@@ -203,9 +217,10 @@ function LongChart() {
             size="small"
             value={days}
             type="number"
-            style={{ width: 150, marginLeft: '16px' }}
+            className={classes.daysInput}
             label="Historical Days"
             variant="outlined"
+            InputLabelProps={{ className: classes.daysInputLabel }}
             // InputProps={{
             //   endAdornment: (
             //     <InputAdornment position="end">


### PR DESCRIPTION
# Task:

Just a couple of style improvements targeted towards smaller screen sizes.

## Description

All the following images are of iPhone 12 Pro (width: 390px)

### Before - without proper spacing
<img width="385" alt="without-proper-spacing" src="https://user-images.githubusercontent.com/12045121/202109778-19b4a54a-9fd0-4b5f-95f7-f73afcc42dd9.png">

### After - with uniform spacing
<img width="377" alt="uniform-spacing" src="https://user-images.githubusercontent.com/12045121/202109823-b6333322-f72c-40dc-bdef-7f67f53d169c.png">

### Before - label getting overlapped
<img width="464" alt="old-label-overlap" src="https://user-images.githubusercontent.com/12045121/202110089-ed8c4593-b74f-4963-89a8-0e1c8b855753.png">

### After - no label overlap
<img width="430" alt="no-label-overlap" src="https://user-images.githubusercontent.com/12045121/202110150-ca72e3b5-302c-4c04-818c-454d5ef6d20d.png">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update
