### PR TITLE
[Fix] Layout issue caused by short squeeth close dropdown

### DIFF
--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -1061,6 +1061,9 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
                 inputProps={{ 'aria-label': 'Without label' }}
                 style={{ padding: '5px 0px', width: '100%', textAlign: 'left' }}
                 id="close-short-type-select"
+                MenuProps={{
+                  disableScrollLock: true,
+                }}
               >
                 <MenuItem value={CloseType.FULL} id="close-short-full-close">
                   Full Close


### PR DESCRIPTION
# Task:

Layout shifts while changing the short squeeth close from dropdown, This PR Fixes that.

## Description

Before:

https://user-images.githubusercontent.com/52928941/205659331-cce2d83b-549d-487a-86ef-b5f4d8882001.mov

After: 

https://user-images.githubusercontent.com/52928941/205659555-d3fefefd-be9c-4570-abbc-99e37622d2ef.mov

Change comparison in dev tools:


https://user-images.githubusercontent.com/52928941/205706256-c580247a-99dc-4e69-8da3-a54b8b2f3135.mov



## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files