### PR TITLE
[Fix] Layout shift in slippage & price impact container on trade and crab strategy

### DIFF
--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2.tsx
@@ -139,6 +139,11 @@ const useStyles = makeStyles((theme) =>
       fontWeight: 500,
       fontSize: '13px',
     },
+    slippageContainer: {
+      [theme.breakpoints.down('xs')]: {
+        flexWrap: 'wrap',
+      },
+    },
   }),
 )
 
@@ -676,7 +681,13 @@ const CrabTradeV2: React.FC<CrabTradeV2Type> = ({ maxCap, depositedAmount }) => 
                 />
               ) : null}
 
-              <Box display="flex" alignItems="center" justifyContent="space-between" gridGap="12px" flexWrap="wrap">
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                gridGap="12px"
+                className={classes.slippageContainer}
+              >
                 <Metric
                   label="Slippage"
                   value={formatNumber(slippage) + '%'}

--- a/packages/frontend/src/components/Trade/Long/index.tsx
+++ b/packages/frontend/src/components/Trade/Long/index.tsx
@@ -269,6 +269,11 @@ const useStyles = makeStyles((theme) =>
       fontSize: '15px',
       marginLeft: theme.spacing(0.5),
     },
+    slippageContainer: {
+      [theme.breakpoints.down('xs')]: {
+        flexWrap: 'wrap',
+      },
+    },
   }),
 )
 
@@ -534,9 +539,9 @@ const OpenLong: React.FC<BuyProps> = ({ activeStep = 0, open }) => {
                 display="flex"
                 alignItems="center"
                 justifyContent="space-between"
-                flexWrap="wrap"
                 gridGap="12px"
                 marginTop="24px"
+                className={classes.slippageContainer}
               >
                 <Metric
                   label="Slippage"
@@ -901,7 +906,7 @@ const CloseLong: React.FC<BuyProps> = () => {
             justifyContent="space-between"
             gridGap="12px"
             marginTop="24px"
-            flexWrap="wrap"
+            className={classes.slippageContainer}
           >
             <Metric
               label="Slippage"

--- a/packages/frontend/src/components/Trade/Short/index.tsx
+++ b/packages/frontend/src/components/Trade/Short/index.tsx
@@ -224,6 +224,11 @@ const useStyles = makeStyles((theme) =>
       alignItems: 'center',
       pointerEvents: 'auto',
     },
+    slippageContainer: {
+      [theme.breakpoints.down('xs')]: {
+        flexWrap: 'wrap',
+      },
+    },
   }),
 )
 
@@ -625,7 +630,7 @@ const OpenShort: React.FC<SellType> = ({ open }) => {
                 justifyContent="space-between"
                 gridGap="12px"
                 marginTop="12px"
-                flexWrap="wrap"
+                className={classes.slippageContainer}
               >
                 <Metric
                   label="Slippage"
@@ -1176,7 +1181,7 @@ const CloseShort: React.FC<SellType> = ({ open }) => {
               justifyContent="space-between"
               gridGap="12px"
               marginTop="12px"
-              flexWrap="wrap"
+              className={classes.slippageContainer}
             >
               <Metric
                 label="Slippage"


### PR DESCRIPTION
# Task:

This PR fixes the layout shift when price impact/slippage is two-digit in trade and crab strategy

## Description
Before 


https://user-images.githubusercontent.com/52928941/205844063-6763367d-9578-4edb-a24d-d825b2620683.mov

After


https://user-images.githubusercontent.com/52928941/205844086-a40f9570-f2da-4253-935c-83b4877281a7.mov


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files