### PR TITLE
fix: nav items getting overlapped

### DIFF
--- a/packages/frontend/src/components/Button/WalletButton.tsx
+++ b/packages/frontend/src/components/Button/WalletButton.tsx
@@ -92,7 +92,7 @@ const WalletButton: React.FC = () => {
   const { ensName } = useENS(address)
 
   const shortAddress = useMemo(
-    () => (address ? address.slice(0, 8) + '...' + address.slice(address.length - 8, address.length) : ''),
+    () => (address ? address.slice(0, 6) + '...' + address.slice(address.length - 4, address.length) : ''),
     [address],
   )
 


### PR DESCRIPTION
# Task:

Nav items getting overlapped.

## Description

Solution: Doesn't make sense to show that many characters for the wallet address IMO. To keep it uniform with the squeeth address, let's show only the starting 6 and the ending 4 chars.

### Before
<img width="1285" alt="Screenshot 2022-12-06 at 12 37 27 PM" src="https://user-images.githubusercontent.com/12045121/205844424-3cd68d01-dacc-4140-8f37-e73d91255336.png">

### After
<img width="1258" alt="Screenshot 2022-12-06 at 12 37 35 PM" src="https://user-images.githubusercontent.com/12045121/205844433-bf648084-6428-458b-bbde-3c1a2bf13222.png">

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files