### PR TITLE
[Feature] Add load more button to strategy hedges for smooth user experience

### DIFF
--- a/packages/frontend/src/components/Strategies/Crab/StrategyHistoryV2.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/StrategyHistoryV2.tsx
@@ -65,6 +65,7 @@ const useStyles = makeStyles((theme) =>
     moreButtonContainer: {
       display: 'flex',
       justifyContent: 'center',
+      marginBottom:'24px',
     },
     moreButton: {
       textTransform: 'none',
@@ -126,7 +127,7 @@ export const CrabStrategyV2History: React.FC = () => {
       <div ref={bottomRef} />
       {showMore && (
         <div className={classes.moreButtonContainer}>
-          <Button className={classes.moreButton} onClick={onClickLoadMore} color="primary" variant="outlined">
+          <Button size="large" className={classes.moreButton} onClick={onClickLoadMore} color="primary" variant="outlined">
             Load More
           </Button>
         </div>

--- a/packages/frontend/src/components/Strategies/Crab/StrategyHistoryV2.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/StrategyHistoryV2.tsx
@@ -1,14 +1,15 @@
-import { IconButton, Typography, Link } from '@material-ui/core'
+import { IconButton, Typography, Link, Button } from '@material-ui/core'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 import OpenInNewIcon from '@material-ui/icons/OpenInNew'
-import React from 'react'
+import React, { useRef, useCallback } from 'react'
 import clsx from 'clsx'
-import { useAtomValue } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 
 import { EtherscanPrefix } from '@constants/index'
 import { useCrabStrategyV2TxHistory } from '@hooks/useCrabV2AuctionHistory'
 import { networkIdAtom } from '@state/wallet/atoms'
 import { formatNumber } from '@utils/formatter'
+import { visibleStrategyHedgesAtom } from '@state/crab/atoms'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -61,14 +62,29 @@ const useStyles = makeStyles((theme) =>
       alignItems: 'center',
       flexBasis: 'max-content',
     },
+    moreButtonContainer: {
+      display: 'flex',
+      justifyContent: 'center',
+    },
+    moreButton: {
+      textTransform: 'none',
+    },
   }),
 )
 
 export const CrabStrategyV2History: React.FC = () => {
   const classes = useStyles()
-  const { data } = useCrabStrategyV2TxHistory()
-
+  const [visibleHedges, setVisibleHedges] = useAtom(visibleStrategyHedgesAtom)
+  const { data, showMore } = useCrabStrategyV2TxHistory()
+  const bottomRef = useRef<HTMLDivElement>(null)
   const networkId = useAtomValue(networkIdAtom)
+
+  const onClickLoadMore = useCallback(() => {
+    setVisibleHedges(visibleHedges + 10)
+    setTimeout(() => {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }, 200)
+  }, [visibleHedges, setVisibleHedges])
 
   return (
     <div className={classes.container}>
@@ -107,6 +123,14 @@ export const CrabStrategyV2History: React.FC = () => {
           </div>
         )
       })}
+      <div ref={bottomRef} />
+      {showMore && (
+        <div className={classes.moreButtonContainer}>
+          <Button className={classes.moreButton} onClick={onClickLoadMore} color="primary" variant="outlined">
+            Load More
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/frontend/src/hooks/useCrabV2AuctionHistory.ts
+++ b/packages/frontend/src/hooks/useCrabV2AuctionHistory.ts
@@ -7,9 +7,11 @@ import { toTokenAmount } from '@utils/calculations'
 import { WETH_DECIMALS, OSQUEETH_DECIMALS } from '../constants'
 import { squeethClient } from '@utils/apollo-client'
 import { networkIdAtom } from 'src/state/wallet/atoms'
+import { visibleStrategyHedgesAtom } from '@state/crab/atoms'
 
 export const useCrabStrategyV2TxHistory = () => {
   const networkId = useAtomValue(networkIdAtom)
+  const visibleHedges = useAtomValue(visibleStrategyHedgesAtom)
   const { data, loading } = useQuery<crabV2Auctions>(CRAB_V2_AUCTION_QUERY, {
     fetchPolicy: 'cache-and-network',
     client: squeethClient[networkId],
@@ -29,6 +31,7 @@ export const useCrabStrategyV2TxHistory = () => {
 
   return {
     loading,
-    data: uiData,
+    data: uiData?.slice(0, visibleHedges),
+    showMore: (uiData ?? []).length > visibleHedges,
   }
 }

--- a/packages/frontend/src/state/crab/atoms.ts
+++ b/packages/frontend/src/state/crab/atoms.ts
@@ -13,6 +13,7 @@ export const crabStrategyCollatRatioAtom = atom(0)
 export const crabStrategyLiquidationPriceAtom = atom(BIG_ZERO)
 export const timeAtLastHedgeAtom = atom(0)
 export const loadingAtom = atom(true)
+export const visibleStrategyHedgesAtom = atom<number>(10)
 
 export const maxCapAtomV2 = atom(BIG_ZERO)
 export const crabStrategyVaultAtomV2 = atom<Vault | null>(null)
@@ -62,13 +63,16 @@ export const crabv2StrategyFilterStartDateAtom = atom<Date>(new Date(CRABV2_STAR
 export const crabv2StrategyFilterEndDateAtom = atom<Date>(new Date())
 
 export const useCrabPnLV2ChartData = () => {
-
   const startDate = useAtomValue(crabv2StrategyFilterStartDateAtom)
   const endDate = useAtomValue(crabv2StrategyFilterEndDateAtom)
 
   return useQuery(
-    ['pnlChart', {startDate, endDate} ],
-    async () => getCrabPnlV2ChartData(Number(startDate.valueOf().toString().slice(0, -3)), Number(endDate.valueOf().toString().slice(0, -3))),
+    ['pnlChart', { startDate, endDate }],
+    async () =>
+      getCrabPnlV2ChartData(
+        Number(startDate.valueOf().toString().slice(0, -3)),
+        Number(endDate.valueOf().toString().slice(0, -3)),
+      ),
     {
       staleTime: Infinity,
       refetchOnWindowFocus: true,


### PR DESCRIPTION
# Task:

Add a load more button on strategy hedges.

## Description

This would show 10 initial entries with a load more button (if there are more entries), once you click on load more it loads the next 10 and navigates to the end of the page smoothly.

UX Comparison

Before 

https://user-images.githubusercontent.com/52928941/205851337-e7ae9436-a6ba-4383-8eea-9f4f482ee12e.mov

After 

https://user-images.githubusercontent.com/52928941/205851367-e18546a6-cad6-4663-b088-d4241df16cd9.mov


## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Testing code
- [ ] Document update or config files