### PR TITLE
style: further fixes the nav items overlap issue

### DIFF
--- a/packages/frontend/src/components/Nav.tsx
+++ b/packages/frontend/src/components/Nav.tsx
@@ -93,12 +93,6 @@ const useStyles = makeStyles((theme) =>
         marginBottom: theme.spacing(1),
       },
     },
-    contractAddress: {
-      width: '200px',
-      [theme.breakpoints.down('md')]: {
-        width: '50px',
-      },
-    },
   }),
 )
 
@@ -181,7 +175,6 @@ const Nav: React.FC = () => {
             onClick={() => {
               setCopied(oSqueeth)
             }}
-            className={classes.contractAddress}
           >
             {isCopied ? (
               <>Copied</>


### PR DESCRIPTION
# Task:

Further fixes the nav items overlapping issue by reducing the width of contract address button.

## Description

### Before
<img width="1281" alt="Screenshot 2022-12-06 at 5 30 33 PM" src="https://user-images.githubusercontent.com/12045121/205906283-ced06ad6-3327-491b-9370-635160a49b37.png">

### After
<img width="1275" alt="Screenshot 2022-12-06 at 5 31 04 PM" src="https://user-images.githubusercontent.com/12045121/205906363-5bd2ee62-592b-42eb-8dd8-5e0c781d1ce0.png">


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files