### PR TITLE
[Audit FIX] pop the userDepositsIndex on FullWithdraw; prevent DDOS

### DIFF
--- a/packages/crab-netting/src/CrabNetting.sol
+++ b/packages/crab-netting/src/CrabNetting.sol
@@ -296,6 +296,7 @@ contract CrabNetting is Ownable, EIP712 {
             } else {
                 toRemove -= r.amount;
                 delete deposits[userDepositsIndex[msg.sender][i - 1]];
+                userDepositsIndex[msg.sender].pop();
             }
         }
         IERC20(usdc).transfer(msg.sender, _amount);

--- a/packages/crab-netting/src/CrabNetting.sol
+++ b/packages/crab-netting/src/CrabNetting.sol
@@ -340,6 +340,7 @@ contract CrabNetting is Ownable, EIP712 {
             } else {
                 toRemove -= r.amount;
                 delete withdraws[userWithdrawsIndex[msg.sender][i - 1]];
+                userWithdrawsIndex[msg.sender].pop();
             }
         }
         IERC20(crab).transfer(msg.sender, _amount);

--- a/packages/crab-netting/test/Deposit.t.sol
+++ b/packages/crab-netting/test/Deposit.t.sol
@@ -130,4 +130,16 @@ contract DepositTest is BaseForkSetup {
         netting.withdrawUSDC(2 * 1e6);
         vm.stopPrank();
     }
+
+    function testDepositAndWithdrawFail_POC() public {
+        netting.setMinUSDC(10e6);
+        vm.startPrank(depositor);
+        usdc.approve(address(netting), 10e9);
+        netting.depositUSDC(10e6);
+
+        for (uint256 i = 0; i < 100; i++) {
+            netting.depositUSDC(10e6);
+            netting.withdrawUSDC{gas: 200_000}(10e6);
+        }
+    }
 }

--- a/packages/crab-netting/test/Deposit.t.sol
+++ b/packages/crab-netting/test/Deposit.t.sol
@@ -142,4 +142,16 @@ contract DepositTest is BaseForkSetup {
             netting.withdrawUSDC{gas: 200_000}(10e6);
         }
     }
+
+    function testWithdrawAndDeQueueFail_POC() public {
+        netting.setMinCrab(1);
+        vm.startPrank(withdrawer);
+        crab.approve(address(netting), 20e18);
+        netting.queueCrabForWithdrawal(10e18);
+
+        for (uint256 i = 0; i < 100; i++) {
+            netting.queueCrabForWithdrawal(10);
+            netting.dequeueCrab{gas: 200_000}(10);
+        }
+    }
 }


### PR DESCRIPTION
https://github.com/sherlock-audit/2022-11-opyn-judging/blob/f650851bbd918a3c476d423ddb6efae6ad864b3a/011-M/029.md

withdraw looping more than required if user does a fullWithdraw. So we pop the full withdrawn index , so that it is not visited again

fixes https://github.com/sherlock-audit/2022-11-opyn-judging/issues/156