### PR TITLE
[Audit Fix] added ability for admin to advance pointers in crab netting

### DIFF
--- a/packages/crab-netting/src/CrabNetting.sol
+++ b/packages/crab-netting/src/CrabNetting.sol
@@ -183,6 +183,8 @@ contract CrabNetting is Ownable, EIP712 {
     event SetOTCPriceTolerance(uint256 previousTolerance, uint256 newOtcPriceTolerance);
     event SetMinCrab(uint256 amount);
     event SetMinUSDC(uint256 amount);
+    event SetDepositsIndex(uint256 newDepositsIndex);
+    event SetWithdrawsIndex(uint256 newWithdrawsIndex);
     event NonceTrue(address sender, uint256 nonce);
     event ToggledAuctionLive(bool isAuctionLive);
 
@@ -252,6 +254,24 @@ contract CrabNetting is Ownable, EIP712 {
     function setMinCrab(uint256 _amount) external onlyOwner {
         minCrabAmount = _amount;
         emit SetMinCrab(_amount);
+    }
+
+    /**
+     * @notice set the depositIndex so that we want to skip processing some deposits
+     * @param _newDepositsIndex the new deposits index
+     */
+    function setDepositsIndex(uint256 _newDepositsIndex) external onlyOwner {
+        depositsIndex = _newDepositsIndex;
+        emit SetDepositsIndex(_newDepositsIndex);
+    }
+
+    /**
+     * @notice set the withdraw index so that we want to skip processing some withdraws
+     * @param _newWithdrawsIndex the new withdraw index
+     */
+    function setWithdrawsIndex(uint256 _newWithdrawsIndex) external onlyOwner {
+        withdrawsIndex = _newWithdrawsIndex;
+        emit SetWithdrawsIndex(_newWithdrawsIndex);
     }
 
     /**

--- a/packages/crab-netting/test/SkipDeposits.t.sol
+++ b/packages/crab-netting/test/SkipDeposits.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {BaseForkSetup} from "./BaseForkSetup.t.sol";
+
+contract SkipDeposits is BaseForkSetup {
+    function setUp() public override {
+        BaseForkSetup.setUp(); // gives you netting, depositor, withdrawer, usdc, crab
+
+        vm.startPrank(0x57757E3D981446D585Af0D9Ae4d7DF6D64647806);
+        usdc.transfer(depositor, 20e6);
+        vm.stopPrank();
+
+        vm.prank(0x06CECFbac34101aE41C88EbC2450f8602b3d164b);
+        crab.transfer(withdrawer, 20e18);
+    }
+
+    function testSkipDeposits() public {
+        netting.setMinUSDC(1e6);
+        vm.startPrank(depositor);
+        usdc.approve(address(netting), 2 * 1e6);
+        netting.depositUSDC(1e6);
+        netting.depositUSDC(1e6);
+        vm.stopPrank();
+        assertEq(netting.depositsQueued(), 2e6);
+        netting.setDepositsIndex(1);
+        assertEq(netting.depositsQueued(), 1e6);
+    }
+
+    function testSkipWithdraws() public {
+        netting.setMinCrab(1e18);
+        vm.startPrank(withdrawer);
+        crab.approve(address(netting), 2 * 1e18);
+        netting.queueCrabForWithdrawal(1e18);
+        netting.queueCrabForWithdrawal(1e18);
+        vm.stopPrank();
+        assertEq(netting.withdrawsQueued(), 2e18);
+        netting.setWithdrawsIndex(1);
+        assertEq(netting.withdrawsQueued(), 1e18);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2022-11-opyn-judging/issues/148

When a user dequeues a withdraw or deposit it leaves a blank entry in the withdraw/deposit. This entry must be read from memory and skipped when processing the withdraws/deposits which uses gas for each blank entry. An adversary could exploit this to DOS the contract. By making a large number of these blank deposits they could make it impossible to process any auction.

So we added the ability to advance the withdraws and the depositIndex