### PR TITLE
[Audit Fix] anyone can turn off auctionLive flag after 7 days of auction live tur…

### DIFF
--- a/packages/crab-netting/src/CrabNetting.sol
+++ b/packages/crab-netting/src/CrabNetting.sol
@@ -95,6 +95,9 @@ contract CrabNetting is Ownable, EIP712 {
     /// @dev twap period to use for auction calculations
     uint32 public auctionTwapPeriod = 420 seconds;
 
+    /// @dev time of last auctionLive toggle
+    uint256 public lastAuctionLive;
+
     /// @dev min USDC amounts to withdraw or deposit via netting
     uint256 public minUSDCAmount;
 
@@ -224,7 +227,18 @@ contract CrabNetting is Ownable, EIP712 {
      */
     function toggleAuctionLive() external onlyOwner {
         isAuctionLive = !isAuctionLive;
+        lastAuctionLive = block.timestamp;
         emit ToggledAuctionLive(isAuctionLive);
+    }
+
+    /**
+     * @dev allows anyone to turn off the auction; after a week of auction gone live
+     */
+    function turnOffAuctionLive() external {
+        if (block.timestamp > lastAuctionLive + 1 weeks) {
+            isAuctionLive = false;
+        }
+        emit ToggledAuctionLive(false);
     }
 
     /**

--- a/packages/crab-netting/test/AuctionLiveToggles.sol
+++ b/packages/crab-netting/test/AuctionLiveToggles.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {BaseForkSetup} from "./BaseForkSetup.t.sol";
+
+contract DepositTest is BaseForkSetup {
+    function setUp() public override {
+        BaseForkSetup.setUp(); // gives you netting, depositor, withdrawer, usdc, crab
+    }
+
+    function testTurnOffToggle() public {
+        netting.toggleAuctionLive();
+        skip(8 * 24 * 60 * 60);
+        netting.turnOffAuctionLive();
+        assertFalse(netting.isAuctionLive());
+    }
+}


### PR DESCRIPTION
fixes: https://github.com/sherlock-audit/2022-11-opyn-judging/issues/83

Users could have permanently locked up their funds if auctionLive is left turned on

So we enable anyone to turn off auction if the auction has been live for a week