### PR TITLE
fix: show 3 strategy hedges initially and show 3 incrementally

### DIFF
--- a/packages/frontend/src/components/Strategies/Crab/StrategyHistoryV2.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/StrategyHistoryV2.tsx
@@ -65,7 +65,7 @@ const useStyles = makeStyles((theme) =>
     moreButtonContainer: {
       display: 'flex',
       justifyContent: 'center',
-      marginBottom:'24px',
+      marginBottom: '24px',
     },
     moreButton: {
       textTransform: 'none',
@@ -81,7 +81,7 @@ export const CrabStrategyV2History: React.FC = () => {
   const networkId = useAtomValue(networkIdAtom)
 
   const onClickLoadMore = useCallback(() => {
-    setVisibleHedges(visibleHedges + 10)
+    setVisibleHedges(visibleHedges + 3)
     setTimeout(() => {
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
     }, 200)
@@ -127,7 +127,13 @@ export const CrabStrategyV2History: React.FC = () => {
       <div ref={bottomRef} />
       {showMore && (
         <div className={classes.moreButtonContainer}>
-          <Button size="large" className={classes.moreButton} onClick={onClickLoadMore} color="primary" variant="outlined">
+          <Button
+            size="large"
+            className={classes.moreButton}
+            onClick={onClickLoadMore}
+            color="primary"
+            variant="outlined"
+          >
             Load More
           </Button>
         </div>

--- a/packages/frontend/src/state/crab/atoms.ts
+++ b/packages/frontend/src/state/crab/atoms.ts
@@ -13,7 +13,7 @@ export const crabStrategyCollatRatioAtom = atom(0)
 export const crabStrategyLiquidationPriceAtom = atom(BIG_ZERO)
 export const timeAtLastHedgeAtom = atom(0)
 export const loadingAtom = atom(true)
-export const visibleStrategyHedgesAtom = atom<number>(10)
+export const visibleStrategyHedgesAtom = atom<number>(3)
 
 export const maxCapAtomV2 = atom(BIG_ZERO)
 export const crabStrategyVaultAtomV2 = atom<Vault | null>(null)


### PR DESCRIPTION
# Task:

Show 3 records initially and fetch 3 incrementally in strategy hedges (crab)

## Description


https://user-images.githubusercontent.com/52928941/206382104-f8f63711-d22a-4b68-8270-64b7655cdff2.mov


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files