### PR TITLE
fix: small metric padding

### DIFF
--- a/packages/frontend/src/components/Metric.tsx
+++ b/packages/frontend/src/components/Metric.tsx
@@ -9,7 +9,7 @@ interface StyleProps {
 const useStyles = makeStyles((theme) =>
   createStyles({
     container: {
-      padding: (props: StyleProps): string => (props.isSmall ? '16px 20px' : '20px 24px'),
+      padding: (props: StyleProps): string => (props.isSmall ? '16px 16px' : '20px 24px'),
       backgroundColor: theme.palette.background.stone,
       borderRadius: '12px',
     },


### PR DESCRIPTION
# Task:

As discussed with @iamoperand, reducing the padding for small metric component due to width increasing issue of trade card caused by slippage and price impact value metrics


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files