### PR TITLE
fix: remove `flash` from transaction history on bull

### DIFF
--- a/packages/frontend/src/constants/enums.ts
+++ b/packages/frontend/src/constants/enums.ts
@@ -33,8 +33,8 @@ export enum TransactionType {
   CRAB_V2_USDC_FLASH_WITHDRAW = 'Withdraw USDC from crab V2',
   OTC_DEPOSIT = 'Deposit USDC to crab v2',
   OTC_WITHDRAW = 'Withdraw USDC from crab V2',
-  BULL_FLASH_DEPOSIT = 'Flash deposit in bull',
-  BULL_FLASH_WITHDRAW = 'Flash withdraw from bull',
+  BULL_FLASH_DEPOSIT = 'Deposit in bull',
+  BULL_FLASH_WITHDRAW = 'Withdraw from bull',
 }
 
 export enum CloseType {


### PR DESCRIPTION
# Task:

Remove `flash` from transaction history on bull
FIXES ENG-1112

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files