### PR TITLE
fix: update wrong analytics event name in bull withdraw

### DIFF
--- a/packages/frontend/src/components/Strategies/Bull/BullTrade/Withdraw.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/BullTrade/Withdraw.tsx
@@ -92,7 +92,7 @@ const BullWithdraw: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) 
   const { track } = useAmplitude()
 
   const trackUserEnteredWithdrawAmount = useCallback(
-    (amount: BigNumber) => track(BULL_EVENTS.DEPOSIT_BULL_AMOUNT_ENTERED, { amount: amount.toNumber() }),
+    (amount: BigNumber) => track(BULL_EVENTS.WITHDRAW_BULL_AMOUNT_ENTERED, { amount: amount.toNumber() }),
     [track],
   )
   const [trackWithdrawAmountEnteredOnce, resetTracking] = useExecuteOnce(trackUserEnteredWithdrawAmount)


### PR DESCRIPTION
# Task:

Update wrong analytics event name in bull withdraw

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files