### PR TITLE
fix: price impact warnings on crab & bull.

### DIFF
--- a/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
@@ -163,15 +163,14 @@ const BullDeposit: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) =
     const squeethPrice = quote.ethOutForSqth.div(quote.oSqthIn)
     const scalingFactor = new BigNumber(INDEX_SCALE)
     const fundingPeriod = new BigNumber(FUNDING_PERIOD).div(YEAR)
-    const executionVol = new BigNumber(
-      Math.log(scalingFactor.times(squeethPrice).div(normFactor.times(ethIndexPrice)).toNumber()),
-    )
-      .div(fundingPeriod)
-      .sqrt()
-    const showPriceImpactWarning = executionVol
-      .minus(impliedVol)
-      .abs()
-      .gt(BigNumber.max(new BigNumber(impliedVol).times(VOL_PERCENT_SCALAR), VOL_PERCENT_FIXED))
+    const log = Math.log(scalingFactor.times(squeethPrice).div(normFactor.times(ethIndexPrice)).toNumber())
+    const executionVol = new BigNumber(log).div(fundingPeriod).sqrt()
+    const showPriceImpactWarning =
+      log < 0 ||
+      executionVol
+        .minus(impliedVol)
+        .abs()
+        .gt(BigNumber.max(new BigNumber(impliedVol).times(VOL_PERCENT_SCALAR), VOL_PERCENT_FIXED))
     return showPriceImpactWarning
   }, [quote.ethOutForSqth, quote.oSqthIn, normFactor, ethIndexPrice, impliedVol])
 

--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
@@ -171,16 +171,15 @@ const CrabDeposit: React.FC<CrabDepositProps> = ({ onTxnConfirm }) => {
     const squeethPrice = ethAmountOutFromDeposit.div(squeethAmountInFromDeposit)
     const scalingFactor = new BigNumber(INDEX_SCALE)
     const fundingPeriod = new BigNumber(FUNDING_PERIOD).div(YEAR)
-    const executionVol = new BigNumber(
-      Math.log(scalingFactor.times(squeethPrice).div(normFactor.times(ethIndexPrice)).toNumber()),
-    )
-      .div(fundingPeriod)
-      .sqrt()
+    const log = Math.log(scalingFactor.times(squeethPrice).div(normFactor.times(ethIndexPrice)).toNumber())
+    const executionVol = new BigNumber(log).div(fundingPeriod).sqrt()
 
-    const showPriceImpactWarning = executionVol
-      .minus(impliedVol)
-      .abs()
-      .gt(BigNumber.max(new BigNumber(impliedVol).times(VOL_PERCENT_SCALAR), VOL_PERCENT_FIXED))
+    const showPriceImpactWarning =
+      log < 0 ||
+      executionVol
+        .minus(impliedVol)
+        .abs()
+        .gt(BigNumber.max(new BigNumber(impliedVol).times(VOL_PERCENT_SCALAR), VOL_PERCENT_FIXED))
     return showPriceImpactWarning
   }, [impliedVol, ethAmountOutFromDeposit, squeethAmountInFromDeposit, useQueue, ethIndexPrice, normFactor])
 


### PR DESCRIPTION
# Task:

Fix price impact warning for bull & crab when oSQTH value is trading lower than its minimum value. 

FIXES ENG-1124
FIXES ENG-1108

Note: we need to add more aggressive warning for this issue, right now fixing it with price impact warning. 

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files