### PR TITLE
fix: pnl after netting

### DIFF
--- a/packages/frontend/src/components/Strategies/Crab/CrabPositionV2.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabPositionV2.tsx
@@ -188,7 +188,7 @@ const CrabPosition: React.FC = () => {
               }
             />
           ) : null}
-          {pnl.isFinite() && (
+          {pnl.isFinite() && !currentCrabPositionValue.isZero() && (
             <Metric
               label="PnL"
               value={


### PR DESCRIPTION
# Task:

After initiating a deposit, if the crab position is not there shows PnL as -100% 

## Description

Before 

https://user-images.githubusercontent.com/52928941/209642351-fe302010-d62e-4150-be36-7d52b9e5e367.mov

After 

![Screenshot 2022-12-27 at 2 39 09 PM](https://user-images.githubusercontent.com/52928941/209642411-61801f86-e807-4582-ba2b-364352090dff.png)


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files