### PR TITLE
fix: pnl not showing sometimes

### DIFF
--- a/packages/frontend/src/hooks/useCrabPosition/useCrabPosition.ts
+++ b/packages/frontend/src/hooks/useCrabPosition/useCrabPosition.ts
@@ -123,8 +123,10 @@ export const useCrabPositionV2 = (user: string) => {
 
   const { remainingDepositEth: depositedEth, remainingDepositUsd: depositedUsd } = useAppMemo(() => {
     console.log(txHistoryData, 'Crab')
-    if (txHistoryLoading || !txHistoryData || txHistoryData.length === 0)
+    if (txHistoryLoading || !txHistoryData || txHistoryData.length === 0) {
       return { remainingDepositUsd: BIG_ZERO, remainingDepositEth: BIG_ZERO }
+    }
+
     const { totalSharesDeposited, totalSharesWithdrawn, totalUSDDeposit, totalETHDeposit } = txHistoryData?.reduce(
       (acc, tx) => {
         if (
@@ -175,7 +177,10 @@ export const useCrabPositionV2 = (user: string) => {
   }, [currentEthValue, currentQueuedCrabEth, depositedUsd, ethIndexPrice])
 
   useEffect(() => {
-    if (crabLoading || txHistoryLoading || isCrabPositionValueLoading) return
+    if (crabLoading || txHistoryLoading || isCrabPositionValueLoading) {
+      return
+    }
+
     calculateCurrentValue()
   }, [calculateCurrentValue, crabLoading, isCrabPositionValueLoading, txHistoryLoading])
 

--- a/packages/frontend/src/hooks/useETHPrice.ts
+++ b/packages/frontend/src/hooks/useETHPrice.ts
@@ -67,6 +67,10 @@ export const getHistoricEthPrice = async (dateString: string): Promise<BigNumber
 }
 
 export const getHistoricEthPrices = async (timestamps: number[]) => {
+  if (timestamps.length === 0) {
+    return
+  }
+
   const timestampStr = timestamps.join(',')
   const pair = 'ETH/USD'
 

--- a/packages/frontend/src/hooks/useUserCrabV2TxHistory.ts
+++ b/packages/frontend/src/hooks/useUserCrabV2TxHistory.ts
@@ -34,8 +34,8 @@ const getTxTitle = (type: string) => {
 export const useUserCrabV2TxHistory = (user: string, isDescending?: boolean) => {
   const networkId = useAtomValue(networkIdAtom)
   const { usdc } = useAtomValue(addressesAtom)
-  const [ethUsdPriceMap, setEthUsdPriceMap] = useState()
-  const [ethUsdPriceMapLoading, setEthUsdPriceMapLoading] = useState(true)
+  const [ethUsdPriceMap, setEthUsdPriceMap] = useState<Record<number, string> | undefined>()
+  const [ethUsdPriceMapLoading, setEthUsdPriceMapLoading] = useState(false)
   const { data, loading, startPolling, stopPolling } = useQuery<userCrabV2Txes, userCrabV2TxesVariables>(
     USER_CRAB_V2_TX_QUERY,
     {
@@ -48,83 +48,81 @@ export const useUserCrabV2TxHistory = (user: string, isDescending?: boolean) => 
     },
   )
 
+  const crabUserTxes = useAppMemo(() => data?.crabUserTxes ?? [], [data])
+
   //get all timestamps found in the user's history once
   useEffect(() => {
-    let timestampsArr: any[] = []
-    timestampsArr = data?.crabUserTxes ? data?.crabUserTxes.map((tx) => tx.timestamp * 1000) : []
-    if (timestampsArr.length > 0) {
-      getHistoricEthPrices(timestampsArr)
-        .then((result) => {
-          setEthUsdPriceMap(result ?? undefined)
-        })
-        .finally(() => {
-          setEthUsdPriceMapLoading(false)
-        })
-    } else {
-      setEthUsdPriceMapLoading(false)
+    const timestampsArr = crabUserTxes.map((tx) => tx.timestamp * 1000)
+
+    setEthUsdPriceMap(undefined)
+    setEthUsdPriceMapLoading(true)
+
+    getHistoricEthPrices(timestampsArr)
+      .then((result) => {
+        setEthUsdPriceMap(result ?? undefined)
+      })
+      .finally(() => {
+        setEthUsdPriceMapLoading(false)
+      })
+  }, [crabUserTxes])
+
+  const uiData = useAppMemo(() => {
+    if (!ethUsdPriceMap) {
+      return []
     }
-  }, [data?.crabUserTxes, usdc])
 
-  const uiData = useAppMemo(
-    () =>
-      ethUsdPriceMap
-        ? data?.crabUserTxes.map((tx) => {
-            let ethAmount = toTokenAmount(tx.ethAmount, WETH_DECIMALS)
-            let ethUsdValue = ethUsdPriceMap ? ethAmount.multipliedBy(ethUsdPriceMap![Number(tx.timestamp) * 1000]) : 0
+    return crabUserTxes.map((tx) => {
+      let ethAmount = toTokenAmount(tx.ethAmount, WETH_DECIMALS)
+      let ethUsdValue = ethAmount.multipliedBy(ethUsdPriceMap![Number(tx.timestamp) * 1000])
 
-            if (tx.type === CrabStrategyV2TxType.DEPOSIT_V1) {
-              const ethMigrated = new BigNumber(V2_MIGRATION_ETH_AMOUNT)
-              const oSqthMigrated = new BigNumber(V2_MIGRATION_OSQTH_AMOUNT)
+      if (tx.type === CrabStrategyV2TxType.DEPOSIT_V1) {
+        const ethMigrated = new BigNumber(V2_MIGRATION_ETH_AMOUNT)
+        const oSqthMigrated = new BigNumber(V2_MIGRATION_OSQTH_AMOUNT)
 
-              ethAmount = ethMigrated
-                .minus(oSqthMigrated.times(V2_MIGRATION_OSQTH_PRICE))
-                .times(toTokenAmount(tx.lpAmount, WETH_DECIMALS))
-                .div(V2_MIGRATION_SUPPLY)
+        ethAmount = ethMigrated
+          .minus(oSqthMigrated.times(V2_MIGRATION_OSQTH_PRICE))
+          .times(toTokenAmount(tx.lpAmount, WETH_DECIMALS))
+          .div(V2_MIGRATION_SUPPLY)
 
-              ethUsdValue = ethAmount.times(V2_MIGRATION_ETH_PRICE)
-            }
-            if (
-              tx.type === CrabStrategyV2TxType.FLASH_WITHDRAW &&
-              usdc.toLowerCase() === tx.erc20Token?.toLowerCase()
-            ) {
-              ethUsdValue = toTokenAmount(tx.erc20Amount, USDC_DECIMALS)
-            } else if (
-              tx.type === CrabStrategyV2TxType.FLASH_DEPOSIT &&
-              usdc.toLowerCase() === tx.erc20Token?.toLowerCase()
-            ) {
-              ethUsdValue = toTokenAmount(tx.erc20Amount, USDC_DECIMALS).minus(
-                ethUsdPriceMap
-                  ? toTokenAmount(tx.excessEth, 18).multipliedBy(ethUsdPriceMap![Number(tx.timestamp) * 1000])
-                  : 0,
-              )
-            }
-            if (tx.type === CrabStrategyV2TxType.OTC_DEPOSIT || tx.type === CrabStrategyV2TxType.OTC_WITHDRAW) {
-              ethUsdValue = toTokenAmount(tx.erc20Amount, USDC_DECIMALS).minus(
-                toTokenAmount(tx.ethAmount, 18).multipliedBy(
-                  ethUsdPriceMap ? ethUsdPriceMap![Number(tx.timestamp) * 1000] : 0,
-                ),
-              )
-              ethAmount = toTokenAmount(tx.erc20Amount, USDC_DECIMALS).div(
-                toTokenAmount(BIG_ONE, 18).multipliedBy(
-                  ethUsdPriceMap ? ethUsdPriceMap![Number(tx.timestamp) * 1000] : 0,
-                ),
-              )
-            }
-            const lpAmount = toTokenAmount(tx.lpAmount, WETH_DECIMALS)
-            const oSqueethAmount = toTokenAmount(tx.wSqueethAmount, OSQUEETH_DECIMALS)
+        ethUsdValue = ethAmount.times(V2_MIGRATION_ETH_PRICE)
+      }
+      if (tx.type === CrabStrategyV2TxType.FLASH_WITHDRAW && usdc.toLowerCase() === tx.erc20Token?.toLowerCase()) {
+        ethUsdValue = toTokenAmount(tx.erc20Amount, USDC_DECIMALS)
+      } else if (
+        tx.type === CrabStrategyV2TxType.FLASH_DEPOSIT &&
+        usdc.toLowerCase() === tx.erc20Token?.toLowerCase()
+      ) {
+        ethUsdValue = toTokenAmount(tx.erc20Amount, USDC_DECIMALS).minus(
+          ethUsdPriceMap
+            ? toTokenAmount(tx.excessEth, 18).multipliedBy(ethUsdPriceMap![Number(tx.timestamp) * 1000])
+            : 0,
+        )
+      }
 
-            return {
-              ...tx,
-              ethAmount,
-              lpAmount,
-              oSqueethAmount,
-              ethUsdValue,
-              txTitle: getTxTitle(tx.type),
-            }
-          })
-        : [],
-    [data?.crabUserTxes, usdc, ethUsdPriceMap],
-  )
+      if (tx.type === CrabStrategyV2TxType.OTC_DEPOSIT || tx.type === CrabStrategyV2TxType.OTC_WITHDRAW) {
+        ethUsdValue = toTokenAmount(tx.erc20Amount, USDC_DECIMALS).minus(
+          toTokenAmount(tx.ethAmount, 18).multipliedBy(
+            ethUsdPriceMap ? ethUsdPriceMap![Number(tx.timestamp) * 1000] : 0,
+          ),
+        )
+        ethAmount = toTokenAmount(tx.erc20Amount, USDC_DECIMALS).div(
+          toTokenAmount(BIG_ONE, 18).multipliedBy(ethUsdPriceMap ? ethUsdPriceMap![Number(tx.timestamp) * 1000] : 0),
+        )
+      }
+
+      const lpAmount = toTokenAmount(tx.lpAmount, WETH_DECIMALS)
+      const oSqueethAmount = toTokenAmount(tx.wSqueethAmount, OSQUEETH_DECIMALS)
+
+      return {
+        ...tx,
+        ethAmount,
+        lpAmount,
+        oSqueethAmount,
+        ethUsdValue,
+        txTitle: getTxTitle(tx.type),
+      }
+    })
+  }, [crabUserTxes, usdc, ethUsdPriceMap])
 
   return {
     loading: loading || ethUsdPriceMapLoading,


### PR DESCRIPTION
# Task:

### Fix PnL not showing 
<img width="1250" alt="Screen Shot 2022-12-27 at 10 57 55 AM" src="https://user-images.githubusercontent.com/12045121/209806679-6105df59-f6be-43cb-9e97-3b07dc2ae4eb.png">

### Fix "Deposited Amount" showing 0
<img width="670" alt="Screen Shot 2022-12-27 at 10 43 00 PM" src="https://user-images.githubusercontent.com/12045121/209846622-8520a280-476e-4669-a679-3344cac599f3.png">


## Description

The issue was happening whenever we switched from one wallet to another, with both wallet having crab transactions. 

Reason: Immediately after switching the wallet `timestampsArr` got updated but `ethUsdPriceMap` didn't (still getting fetched), as a result the corresponding `ethUsdValue` was coming out to be null.

### Before
https://user-images.githubusercontent.com/12045121/209807783-7644b238-b787-4a64-b33f-29b36c61dd58.mov



### After
https://user-images.githubusercontent.com/12045121/209807787-e58d3637-f4cc-4d18-b2de-e3ae3157b5ac.mov



Fixes ENG-1194

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files