### PR TITLE
feat: split uniswap fees from price impact on bull

### DIFF
--- a/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
@@ -78,6 +78,7 @@ const BullDeposit: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) =
     usdcPoolFee: 0,
     priceImpact: 0,
     wethToLend: BIG_ZERO,
+    poolFee: 0,
   })
 
   const { data: balance } = useWalletBalance()
@@ -98,7 +99,11 @@ const BullDeposit: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) =
     getFlashBullDepositParams(new BigNumber(ethToDeposit))
       .then((_quote) => {
         console.log('', ethToDeposit.toString(), depositAmountRef.current)
-        if (ethToDeposit === depositAmountRef.current) setQuote(_quote)
+        if (ethToDeposit === depositAmountRef.current) {
+          let quotePriceImpact = _quote.priceImpact
+          if (_quote.poolFee) quotePriceImpact = _quote.priceImpact - _quote.poolFee
+          setQuote({ ..._quote, priceImpact: quotePriceImpact })
+        }
       })
       .finally(() => {
         if (ethToDeposit === depositAmountRef.current) setQuoteLoading(false)
@@ -260,8 +265,8 @@ const BullDeposit: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) =
             className={classes.slippageContainer}
           >
             <Metric
-              label="Slippage"
-              value={formatNumber(slippage) + '%'}
+              label="Uniswap Fee"
+              value={formatNumber(quote.poolFee) + '%'}
               isSmall
               flexDirection="row"
               justifyContent="space-between"

--- a/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
@@ -276,7 +276,7 @@ const BullDeposit: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) =
             <Box display="flex" alignItems="center" gridGap="12px" flex="1">
               <Metric
                 label="Price Impact"
-                value={formatNumber(quote.priceImpact) + '%'}
+                value={formatNumber(quote.priceImpact < 0 ? 0 : quote.priceImpact) + '%'}
                 isSmall
                 flexDirection="row"
                 justifyContent="space-between"

--- a/packages/frontend/src/components/Strategies/Bull/BullTrade/Withdraw.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/BullTrade/Withdraw.tsx
@@ -81,6 +81,7 @@ const BullWithdraw: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) 
     ethInForUsdc: BIG_ZERO,
     oSqthOut: BIG_ZERO,
     usdcOut: BIG_ZERO,
+    poolFee: 0,
   })
 
   const getFlashBullWithdrawParams = useGetFlashWithdrawParams()
@@ -114,7 +115,11 @@ const BullWithdraw: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) 
     setQuoteLoading(true)
     getFlashBullWithdrawParams(new BigNumber(bullToWithdraw))
       .then((_quote) => {
-        if (bullToWithdraw === withdrawAmountRef.current) setQuote(_quote)
+        if (bullToWithdraw === withdrawAmountRef.current) {
+          let quotePriceImpact = _quote.priceImpact
+          if (_quote.poolFee) quotePriceImpact = _quote.priceImpact - _quote.poolFee
+          setQuote({ ..._quote, priceImpact: quotePriceImpact })
+        }
       })
       .finally(() => {
         if (bullToWithdraw === withdrawAmountRef.current) setQuoteLoading(false)
@@ -263,8 +268,8 @@ const BullWithdraw: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) 
             className={classes.slippageContainer}
           >
             <Metric
-              label="Slippage"
-              value={formatNumber(slippage) + '%'}
+              label="Uniswap Fee"
+              value={formatNumber(quote.poolFee) + '%'}
               isSmall
               flexDirection="row"
               justifyContent="space-between"

--- a/packages/frontend/src/state/bull/hooks.ts
+++ b/packages/frontend/src/state/bull/hooks.ts
@@ -268,12 +268,15 @@ export const useGetFlashBulldepositParams = () => {
         const cumulativeSpotPrice = oSqthToMint.times(sqthPrice).plus(usdcToBorrow.div(ethPrice))
         const executionPrice = toTokenAmount(oSqthProceeds, 18).plus(toTokenAmount(usdcProceeds, 18))
 
+        const squeethSpot = oSqthToMint.times(sqthPrice)
+        const usdcSpot = usdcToBorrow.div(ethPrice)
+
         // cumulative uniswap fees
 
-        const poolFee = toTokenAmount(oSqthProceeds, 18)
+        const poolFee = squeethSpot
           .times(UNI_POOL_FEES)
-          .plus(toTokenAmount(usdcProceeds, 18).times(getUSDCPoolFee(network)))
-          .div(executionPrice)
+          .plus(usdcSpot.times(getUSDCPoolFee(network)))
+          .div(cumulativeSpotPrice)
 
         const priceImpact = (1 - executionPrice.div(cumulativeSpotPrice).toNumber()) * 100
 

--- a/packages/frontend/src/state/bull/hooks.ts
+++ b/packages/frontend/src/state/bull/hooks.ts
@@ -212,6 +212,7 @@ export const useGetFlashBulldepositParams = () => {
       usdcPoolFee: getUSDCPoolFee(network),
       priceImpact: 0,
       wethToLend: BIG_ZERO,
+      poolFee: 0,
     }),
     [network],
   )
@@ -267,6 +268,13 @@ export const useGetFlashBulldepositParams = () => {
         const cumulativeSpotPrice = oSqthToMint.times(sqthPrice).plus(usdcToBorrow.div(ethPrice))
         const executionPrice = toTokenAmount(oSqthProceeds, 18).plus(toTokenAmount(usdcProceeds, 18))
 
+        // cumulative uniswap fees
+
+        const poolFee = toTokenAmount(oSqthProceeds, 18)
+          .times(UNI_POOL_FEES)
+          .plus(toTokenAmount(usdcProceeds, 18).times(getUSDCPoolFee(network)))
+          .div(executionPrice)
+
         const priceImpact = (1 - executionPrice.div(cumulativeSpotPrice).toNumber()) * 100
 
         prevState = {
@@ -280,6 +288,7 @@ export const useGetFlashBulldepositParams = () => {
           ethOutForUsdc: toTokenAmount(usdcProceeds, 18),
           usdcIn: usdcToBorrow,
           oSqthIn: oSqthToMint,
+          poolFee: poolFee.div(10000).toNumber(),
         }
 
         const totalToBull = ethToCrab.plus(wethToLend).minus(minEthFromSqth).minus(minEthFromUsdc)
@@ -441,6 +450,7 @@ export const useGetFlashWithdrawParams = () => {
     ethInForUsdc: BIG_ZERO,
     oSqthOut: BIG_ZERO,
     usdcOut: BIG_ZERO,
+    poolFee: 0,
   }
 
   const getFlashWithdrawParams = async (bullToFlashWithdraw: BigNumber) => {
@@ -484,6 +494,13 @@ export const useGetFlashWithdrawParams = () => {
     const cumulativeSpotPrice = wPowerPerpToRedeem.times(sqthPrice).plus(usdcToRepay.div(ethPrice))
     const executionPrice = toTokenAmount(oSqthProceeds, 18).plus(toTokenAmount(usdcProceeds, 18))
 
+    // cumulative uniswap fees
+
+    const poolFee = toTokenAmount(oSqthProceeds, 18)
+      .times(UNI_POOL_FEES)
+      .plus(toTokenAmount(usdcProceeds, 18).times(getUSDCPoolFee(network)))
+      .div(executionPrice)
+
     const priceImpact = (executionPrice.div(cumulativeSpotPrice).toNumber() - 1) * 100
 
     return {
@@ -495,6 +512,7 @@ export const useGetFlashWithdrawParams = () => {
       ethInForUsdc: toTokenAmount(usdcProceeds, 18),
       usdcOut: usdcToRepay,
       oSqthOut: wPowerPerpToRedeem,
+      poolFee: poolFee.div(10000).toNumber(),
     }
   }
 

--- a/packages/frontend/src/state/bull/hooks.ts
+++ b/packages/frontend/src/state/bull/hooks.ts
@@ -497,12 +497,15 @@ export const useGetFlashWithdrawParams = () => {
     const cumulativeSpotPrice = wPowerPerpToRedeem.times(sqthPrice).plus(usdcToRepay.div(ethPrice))
     const executionPrice = toTokenAmount(oSqthProceeds, 18).plus(toTokenAmount(usdcProceeds, 18))
 
+    const squeethSpot = wPowerPerpToRedeem.times(sqthPrice)
+    const usdcSpot = usdcToRepay.div(ethPrice)
+
     // cumulative uniswap fees
 
-    const poolFee = toTokenAmount(oSqthProceeds, 18)
+    const poolFee = squeethSpot
       .times(UNI_POOL_FEES)
-      .plus(toTokenAmount(usdcProceeds, 18).times(getUSDCPoolFee(network)))
-      .div(executionPrice)
+      .plus(usdcSpot.times(getUSDCPoolFee(network)))
+      .div(cumulativeSpotPrice)
 
     const priceImpact = (executionPrice.div(cumulativeSpotPrice).toNumber() - 1) * 100
 


### PR DESCRIPTION
# Task:

Split Uniswap fees on bull deposit/withdraw
FIXES ENG-1180

Before

![Screenshot 2022-12-29 at 1 13 30 PM](https://user-images.githubusercontent.com/52928941/209919667-03621573-503f-4d58-a3dd-f3043c1507f3.png)


After

![Screenshot 2022-12-29 at 1 13 56 PM](https://user-images.githubusercontent.com/52928941/209919704-d9fd7ea1-49a4-4fbc-be31-f1aa01db7825.png)


## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Testing code
- [ ] Document update or config files