### PR TITLE
fix: move setStrategy from crab trade to crab page, where it belongs

### DIFF
--- a/packages/frontend/pages/strategies/crab.tsx
+++ b/packages/frontend/pages/strategies/crab.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { createStyles, makeStyles } from '@material-ui/core/styles'
 
 import CrabTradeV2 from '@components/Strategies/Crab/CrabTradeV2'
 import MyPosition from '@components/Strategies/Crab/MyPosition'
 import About from '@components/Strategies/Crab/About'
 import StrategyPerformance from '@components/Strategies/Crab/StrategyPerformance'
+import { useSetStrategyDataV2 } from '@state/crab/hooks'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -46,7 +47,12 @@ const useStyles = makeStyles((theme) =>
 )
 
 const Crab: React.FC = () => {
+  const setStrategyDataV2 = useSetStrategyDataV2()
   const classes = useStyles()
+
+  useEffect(() => {
+    setStrategyDataV2()
+  }, [setStrategyDataV2])
 
   return (
     <div className={classes.container}>

--- a/packages/frontend/pages/strategies/crab.tsx
+++ b/packages/frontend/pages/strategies/crab.tsx
@@ -5,7 +5,8 @@ import CrabTradeV2 from '@components/Strategies/Crab/CrabTradeV2'
 import MyPosition from '@components/Strategies/Crab/MyPosition'
 import About from '@components/Strategies/Crab/About'
 import StrategyPerformance from '@components/Strategies/Crab/StrategyPerformance'
-import { useSetStrategyDataV2 } from '@state/crab/hooks'
+import { useSetStrategyDataV2, useCurrentCrabPositionValueV2 } from '@state/crab/hooks'
+import { useInitCrabMigration } from '@state/crabMigration/hooks'
 
 const useStyles = makeStyles((theme) =>
   createStyles({
@@ -49,6 +50,9 @@ const useStyles = makeStyles((theme) =>
 const Crab: React.FC = () => {
   const setStrategyDataV2 = useSetStrategyDataV2()
   const classes = useStyles()
+
+  useCurrentCrabPositionValueV2()
+  useInitCrabMigration()
 
   useEffect(() => {
     setStrategyDataV2()

--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/index.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/index.tsx
@@ -1,8 +1,7 @@
 import { Box } from '@material-ui/core'
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useCallback } from 'react'
 import { SqueethTabsNew, SqueethTabNew } from '@components/Tabs'
 
-import { useSetStrategyDataV2 } from '@state/crab/hooks'
 import Deposit from './Deposit'
 import Withdraw from './Withdraw'
 import { useTransactionStatus } from '@state/wallet/hooks'
@@ -14,7 +13,6 @@ import { CrabTransactionConfirmation, CrabTradeType, CrabTradeTransactionType } 
 const CrabTradeV2: React.FC = () => {
   const [depositOption, setDepositOption] = useState(0)
   const [confirmedTransactionData, setConfirmedTransactionData] = useState<CrabTransactionConfirmation | undefined>()
-  const setStrategyData = useSetStrategyDataV2()
   const { confirmed, resetTransactionData, transactionData } = useTransactionStatus()
 
   const confirmationMessage = useAppMemo(() => {
@@ -36,10 +34,6 @@ const CrabTradeV2: React.FC = () => {
     setConfirmedTransactionData(undefined)
     resetTransactionData()
   }, [resetTransactionData, setConfirmedTransactionData])
-
-  useEffect(() => {
-    setStrategyData()
-  }, [setStrategyData])
 
   if (confirmed && confirmedTransactionData?.status) {
     return (


### PR DESCRIPTION
# Task:

Not a bug as such, just wanted to move it to where it belongs.

`setStrategy` is used to set the strategy data (TVL, ETH price at last hedge, max cap) so it should run as soon as the crab page loads, not when the crab trade section loads.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files