### PR TITLE
fix: crab deposit/withdraw warnings

### DIFF
--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
@@ -431,7 +431,7 @@ const CrabDeposit: React.FC<CrabDepositProps> = ({ onTxnConfirm }) => {
           helperText={depositError}
         />
 
-        {depositFundingWarning && (
+        {depositFundingWarning && !useQueue && (
           <div className={classes.notice}>
             <div className={classes.infoIcon}>
               <Tooltip

--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Withdraw.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Withdraw.tsx
@@ -509,7 +509,7 @@ const CrabWithdraw: React.FC<{ onTxnConfirm: (txn: CrabTransactionConfirmation) 
           helperText={withdrawError}
         />
 
-        {withdrawFundingWarning ? (
+        {withdrawFundingWarning && !useQueue ? (
           <div className={classes.notice}>
             <div className={classes.infoIcon}>
               <Tooltip


### PR DESCRIPTION
# Task:

Hide crab yield deposit warning & costly withdrawal warning on standard deposit crab
FIXES ENG-1201

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files