### PR TITLE
fix: highlight strategies link for both bull and crab strategy pages

### DIFF
--- a/packages/frontend/src/components/Nav.tsx
+++ b/packages/frontend/src/components/Nav.tsx
@@ -96,13 +96,21 @@ const useStyles = makeStyles((theme) =>
   }),
 )
 
-export const NavLink: React.FC<{ path: string; name: string }> = ({ path, name }) => {
+export const NavLink: React.FC<{ path: string; name: string; highlightForPaths?: string[] }> = ({
+  path,
+  name,
+  highlightForPaths,
+}) => {
   const classes = useStyles()
   const router = useRouter()
 
   return (
     <Typography
-      className={router.pathname === path ? `${classes.navLink} ${classes.navActive}` : classes.navLink}
+      className={
+        router.pathname === path || highlightForPaths?.includes(router.pathname)
+          ? `${classes.navLink} ${classes.navActive}`
+          : classes.navLink
+      }
       variant="h6"
     >
       <Link href={path}>{name}</Link>
@@ -131,7 +139,11 @@ const Nav: React.FC = () => {
           <div className={classes.navDiv}>
             <div style={{ display: 'flex' }}>
               <NavLink path="/" name="Trade" />
-              <NavLink path="/strategies/crab" name="Strategies" />
+              <NavLink
+                highlightForPaths={['/strategies/crab', '/strategies/bull']}
+                path="/strategies/crab"
+                name="Strategies"
+              />
               {/* <NavLink path="/trade" name="Trade 1" /> */}
               <NavLink path="/positions" name="Positions" />
               <NavLink path="/lp" name="LP" />

--- a/packages/frontend/src/components/Nav.tsx
+++ b/packages/frontend/src/components/Nav.tsx
@@ -223,7 +223,11 @@ const Nav: React.FC = () => {
                 )}
               </Button>
               <NavLink path="/" name="Trade" />
-              <NavLink path="/strategies" name="Strategies" />
+              <NavLink
+                highlightForPaths={['/strategies/crab', '/strategies/bull']}
+                path="/strategies/crab"
+                name="Strategies"
+              />
               <NavLink path="/positions" name="Positions" />
               <NavLink path="/lp" name="LP" />
               <a href="https://opyn.gitbook.io/squeeth/resources/squeeth-faq" target="_blank" rel="noreferrer">


### PR DESCRIPTION
# Task:

Highlight Strategies link in the navigation bar for both bull and crab
FIXES ENG-1289

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files