### PR TITLE
fix: show loading on strategy performance instead of 0 value

### DIFF
--- a/packages/frontend/src/components/Strategies/Bull/StrategyPerformance.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/StrategyPerformance.tsx
@@ -204,89 +204,100 @@ const StrategyPerformance: React.FC = () => {
       <Typography variant="h3" className={classes.sectionTitle}>
         Strategy Performance
       </Typography>
-      <Box display="flex" alignItems="baseline" gridColumnGap="12px" gridRowGap="4px" flexWrap="wrap">
-        <Typography
-          variant="h2"
-          className={clsx(
-            classes.heading,
-            classes.textMonospace,
-            annualizedReturns >= 0 ? classes.colorSuccess : classes.colorError,
-          )}
-        >
-          {annualizedReturns >= 0 && '+'}
-          {formatNumber(annualizedReturns)}%
-        </Typography>
+      {bullEthPnlSeries ? (
+        <>
+          <Box display="flex" alignItems="baseline" gridColumnGap="12px" gridRowGap="4px" flexWrap="wrap">
+            <Typography
+              variant="h2"
+              className={clsx(
+                classes.heading,
+                classes.textMonospace,
+                annualizedReturns >= 0 ? classes.colorSuccess : classes.colorError,
+              )}
+            >
+              {annualizedReturns >= 0 && '+'}
+              {formatNumber(annualizedReturns)}%
+            </Typography>
 
-        <Box display="flex" alignItems="baseline" gridGap="12px">
-          <Typography className={classes.description}>Annualized ETH Return</Typography>
+            <Box display="flex" alignItems="baseline" gridGap="12px">
+              <Typography className={classes.description}>Annualized ETH Return</Typography>
 
-          <Box position="relative" top="3px">
-            <Tooltip title={<TooltipTitle />}>
-              <HelpOutlineIcon fontSize="small" className={classes.infoIcon} />
-            </Tooltip>
-          </Box>
-        </Box>
-      </Box>
-
-      <Box display="flex" gridGap="12px">
-        <Typography className={clsx(classes.description, classes.textMonospace)}>
-          {formatNumber(tvl, 0) + ' ETH'}
-        </Typography>
-        <Typography className={classes.description}>TVL</Typography>
-      </Box>
-
-      <Box display="flex" justifyContent="space-between" alignItems="flex-end" gridGap="12px" flexWrap="wrap">
-        <div>
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Box display="flex" alignItems="center" gridGap="16px" marginTop="16px">
-              <DatePicker
-                id="start-date-strategy-performance"
-                label="Start Date"
-                placeholder="MM/DD/YYYY"
-                format={'MM/dd/yyyy'}
-                value={startDate}
-                minDate={BULL_START_DATE}
-                onChange={(d) => setStartDate(d || new Date())}
-                animateYearScrolling={false}
-                autoOk={true}
-                clearable
-                TextFieldComponent={CustomTextField}
-              />
-
-              <Divider orientation="horizontal" className={classes.divider} />
-
-              <DatePicker
-                id="end-date-strategy-performance"
-                label="End Date"
-                placeholder="MM/DD/YYYY"
-                format={'MM/dd/yyyy'}
-                value={endDate}
-                minDate={startDate}
-                onChange={(d) => setEndDate(d || new Date())}
-                animateYearScrolling={false}
-                autoOk={true}
-                clearable
-                TextFieldComponent={CustomTextField}
-              />
+              <Box position="relative" top="3px">
+                <Tooltip title={<TooltipTitle />}>
+                  <HelpOutlineIcon fontSize="small" className={classes.infoIcon} />
+                </Tooltip>
+              </Box>
             </Box>
-          </MuiPickersUtilsProvider>
-        </div>
-
-        <Box display="flex" flexDirection="column" gridGap="4px" flex="1" flexBasis="200px">
-          <PerformanceMetric label="Historical Returns" value={historicalReturns} />
-          <PerformanceMetric label="Annualized" value={annualizedReturns} />
-        </Box>
-      </Box>
-
-      <Box marginTop="12px">
-        {bullEthPnlSeries ? (
-          <HighchartsReact highcharts={Highcharts} options={chartOptions} />
-        ) : (
-          <Box display="flex" height="346px" width={1} alignItems="center" justifyContent="center">
-            <CircularProgress size={40} className={classes.loadingSpinner} />
           </Box>
-        )}
-      </Box>
+
+          <Box display="flex" gridGap="12px">
+            <Typography className={clsx(classes.description, classes.textMonospace)}>
+              {formatNumber(tvl, 0) + ' ETH'}
+            </Typography>
+            <Typography className={classes.description}>TVL</Typography>
+          </Box>
+
+          <Box display="flex" justifyContent="space-between" alignItems="flex-end" gridGap="12px" flexWrap="wrap">
+            <div>
+              <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                <Box display="flex" alignItems="center" gridGap="16px" marginTop="16px">
+                  <DatePicker
+                    id="start-date-strategy-performance"
+                    label="Start Date"
+                    placeholder="MM/DD/YYYY"
+                    format={'MM/dd/yyyy'}
+                    value={startDate}
+                    minDate={BULL_START_DATE}
+                    onChange={(d) => setStartDate(d || new Date())}
+                    animateYearScrolling={false}
+                    autoOk={true}
+                    clearable
+                    TextFieldComponent={CustomTextField}
+                  />
+
+                  <Divider orientation="horizontal" className={classes.divider} />
+
+                  <DatePicker
+                    id="end-date-strategy-performance"
+                    label="End Date"
+                    placeholder="MM/DD/YYYY"
+                    format={'MM/dd/yyyy'}
+                    value={endDate}
+                    minDate={startDate}
+                    onChange={(d) => setEndDate(d || new Date())}
+                    animateYearScrolling={false}
+                    autoOk={true}
+                    clearable
+                    TextFieldComponent={CustomTextField}
+                  />
+                </Box>
+              </MuiPickersUtilsProvider>
+            </div>
+
+            <Box display="flex" flexDirection="column" gridGap="4px" flex="1" flexBasis="200px">
+              <PerformanceMetric label="Historical Returns" value={historicalReturns} />
+              <PerformanceMetric label="Annualized" value={annualizedReturns} />
+            </Box>
+          </Box>
+
+          <Box marginTop="12px">
+            {bullEthPnlSeries ? (
+              <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+            ) : (
+              <Box display="flex" height="346px" width={1} alignItems="center" justifyContent="center">
+                <CircularProgress size={40} className={classes.loadingSpinner} />
+              </Box>
+            )}
+          </Box>
+        </>
+      ) : (
+        <Box display="flex" alignItems="flex-start" marginTop="8px" height="500px">
+          <Box display="flex" alignItems="center" gridGap="15px">
+            <CircularProgress size={15} className={classes.loadingSpinner} />
+            <Typography className={classes.text}>Fetching strategy performance...</Typography>
+          </Box>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/packages/frontend/src/components/Strategies/Bull/StrategyPerformance.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/StrategyPerformance.tsx
@@ -119,24 +119,20 @@ const TooltipTitle = () => (
   </>
 )
 
-const StrategyPerformance: React.FC = () => {
-  const ethDepositedInEuler = useAtomValue(bullDepositedEthInEulerAtom)
-  const bullCrabBalance = useAtomValue(bullCrabBalanceAtom)
-  const eulerUSDCDebt = useAtomValue(bullEulerUSDCDebtAtom)
-  const crabUSDValue = useAtomValue(crabUSDValueAtom)
-  const ethPrice = useOnChainETHPrice()
+interface StrategyPerformanceProps {
+  strategyPnLSeries: Array<[number, number]>
+  tvl: number
+}
 
+const StrategyPerformance: React.FC<StrategyPerformanceProps> = ({ strategyPnLSeries, tvl }) => {
   const [startDate, setStartDate] = useAtom(bullStrategyFilterStartDateAtom)
   const [endDate, setEndDate] = useAtom(bullStrategyFilterEndDateAtom)
-
-  const query = useBullPnLChartData()
-  const bullEthPnlSeries = query?.data?.data.map((x: ChartDataInfo) => [x.timestamp * 1000, x.bullEthPnl])
 
   const series = [
     {
       name: 'Bull/ETH 🧘🐂 % Return',
       yAxis: 0,
-      data: bullEthPnlSeries,
+      data: strategyPnLSeries,
       tooltip: {
         valueDecimals: 2,
         valueSuffix: '%',
@@ -179,127 +175,141 @@ const StrategyPerformance: React.FC = () => {
   const classes = useStyles()
 
   const numberOfDays = differenceInCalendarDays(endDate, startDate)
-  const hasData = bullEthPnlSeries?.length > 0 ?? false
+  const hasData = strategyPnLSeries?.length > 0
 
-  const historicalReturns = hasData ? bullEthPnlSeries[bullEthPnlSeries.length - 1][1] : 0
+  const historicalReturns = hasData ? strategyPnLSeries[strategyPnLSeries.length - 1][1] : 0
   const annualizedReturns = useMemo(() => {
     return (Math.pow(1 + historicalReturns / 100, 365 / numberOfDays) - 1) * 100
   }, [historicalReturns, numberOfDays])
+
+  return (
+    <>
+      <Box display="flex" alignItems="baseline" gridColumnGap="12px" gridRowGap="4px" flexWrap="wrap">
+        <Typography
+          variant="h2"
+          className={clsx(
+            classes.heading,
+            classes.textMonospace,
+            annualizedReturns >= 0 ? classes.colorSuccess : classes.colorError,
+          )}
+        >
+          {annualizedReturns >= 0 && '+'}
+          {formatNumber(annualizedReturns)}%
+        </Typography>
+
+        <Box display="flex" alignItems="baseline" gridGap="12px">
+          <Typography className={classes.description}>Annualized ETH Return</Typography>
+
+          <Box position="relative" top="3px">
+            <Tooltip title={<TooltipTitle />}>
+              <HelpOutlineIcon fontSize="small" className={classes.infoIcon} />
+            </Tooltip>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box display="flex" gridGap="12px">
+        <Typography className={clsx(classes.description, classes.textMonospace)}>
+          {formatNumber(tvl, 0) + ' ETH'}
+        </Typography>
+        <Typography className={classes.description}>TVL</Typography>
+      </Box>
+
+      <Box display="flex" justifyContent="space-between" alignItems="flex-end" gridGap="12px" flexWrap="wrap">
+        <div>
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <Box display="flex" alignItems="center" gridGap="16px" marginTop="16px">
+              <DatePicker
+                id="start-date-strategy-performance"
+                label="Start Date"
+                placeholder="MM/DD/YYYY"
+                format={'MM/dd/yyyy'}
+                value={startDate}
+                minDate={BULL_START_DATE}
+                onChange={(d) => setStartDate(d || new Date())}
+                animateYearScrolling={false}
+                autoOk={true}
+                clearable
+                TextFieldComponent={CustomTextField}
+              />
+
+              <Divider orientation="horizontal" className={classes.divider} />
+
+              <DatePicker
+                id="end-date-strategy-performance"
+                label="End Date"
+                placeholder="MM/DD/YYYY"
+                format={'MM/dd/yyyy'}
+                value={endDate}
+                minDate={startDate}
+                onChange={(d) => setEndDate(d || new Date())}
+                animateYearScrolling={false}
+                autoOk={true}
+                clearable
+                TextFieldComponent={CustomTextField}
+              />
+            </Box>
+          </MuiPickersUtilsProvider>
+        </div>
+
+        <Box display="flex" flexDirection="column" gridGap="4px" flex="1" flexBasis="200px">
+          <PerformanceMetric label="Historical Returns" value={historicalReturns} />
+          <PerformanceMetric label="Annualized" value={annualizedReturns} />
+        </Box>
+      </Box>
+
+      <Box marginTop="12px">
+        <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+      </Box>
+    </>
+  )
+}
+
+const Wrapper: React.FC = () => {
+  const ethDepositedInEuler = useAtomValue(bullDepositedEthInEulerAtom)
+  const bullCrabBalance = useAtomValue(bullCrabBalanceAtom)
+  const eulerUSDCDebt = useAtomValue(bullEulerUSDCDebtAtom)
+  const crabUSDValue = useAtomValue(crabUSDValueAtom)
+  const ethPrice = useOnChainETHPrice()
+  const query = useBullPnLChartData()
+
+  const strategyPnLSeries = query?.data?.data.map((x: ChartDataInfo) => [x.timestamp * 1000, x.bullEthPnl])
+  const isLoadingPnLSeries = typeof strategyPnLSeries === 'undefined'
 
   // tvl = ethInEuler + (crabInBull * crabPriceInETH) - (debtInEuler / ethPrice)
   const crabPriceInETH = toTokenAmount(crabUSDValue, 18).div(ethPrice)
   const collateralValue = ethDepositedInEuler.plus(bullCrabBalance.times(crabPriceInETH))
   const debtValue = eulerUSDCDebt.div(ethPrice)
-
+  const tvl = collateralValue.minus(debtValue).integerValue()
   const isLoadingTVL =
     ethDepositedInEuler.isZero() ||
     bullCrabBalance.isZero() ||
     crabUSDValue.isZero() ||
     eulerUSDCDebt.isZero() ||
     ethPrice.isZero()
-  const tvl = isLoadingTVL ? 0 : collateralValue.minus(debtValue).integerValue().toNumber()
+
+  const isLoading = isLoadingPnLSeries || isLoadingTVL
+
+  const classes = useStyles()
 
   return (
     <Box display="flex" flexDirection="column" gridGap="8px">
       <Typography variant="h3" className={classes.sectionTitle}>
         Strategy Performance
       </Typography>
-      {bullEthPnlSeries ? (
-        <>
-          <Box display="flex" alignItems="baseline" gridColumnGap="12px" gridRowGap="4px" flexWrap="wrap">
-            <Typography
-              variant="h2"
-              className={clsx(
-                classes.heading,
-                classes.textMonospace,
-                annualizedReturns >= 0 ? classes.colorSuccess : classes.colorError,
-              )}
-            >
-              {annualizedReturns >= 0 && '+'}
-              {formatNumber(annualizedReturns)}%
-            </Typography>
 
-            <Box display="flex" alignItems="baseline" gridGap="12px">
-              <Typography className={classes.description}>Annualized ETH Return</Typography>
-
-              <Box position="relative" top="3px">
-                <Tooltip title={<TooltipTitle />}>
-                  <HelpOutlineIcon fontSize="small" className={classes.infoIcon} />
-                </Tooltip>
-              </Box>
-            </Box>
-          </Box>
-
-          <Box display="flex" gridGap="12px">
-            <Typography className={clsx(classes.description, classes.textMonospace)}>
-              {formatNumber(tvl, 0) + ' ETH'}
-            </Typography>
-            <Typography className={classes.description}>TVL</Typography>
-          </Box>
-
-          <Box display="flex" justifyContent="space-between" alignItems="flex-end" gridGap="12px" flexWrap="wrap">
-            <div>
-              <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                <Box display="flex" alignItems="center" gridGap="16px" marginTop="16px">
-                  <DatePicker
-                    id="start-date-strategy-performance"
-                    label="Start Date"
-                    placeholder="MM/DD/YYYY"
-                    format={'MM/dd/yyyy'}
-                    value={startDate}
-                    minDate={BULL_START_DATE}
-                    onChange={(d) => setStartDate(d || new Date())}
-                    animateYearScrolling={false}
-                    autoOk={true}
-                    clearable
-                    TextFieldComponent={CustomTextField}
-                  />
-
-                  <Divider orientation="horizontal" className={classes.divider} />
-
-                  <DatePicker
-                    id="end-date-strategy-performance"
-                    label="End Date"
-                    placeholder="MM/DD/YYYY"
-                    format={'MM/dd/yyyy'}
-                    value={endDate}
-                    minDate={startDate}
-                    onChange={(d) => setEndDate(d || new Date())}
-                    animateYearScrolling={false}
-                    autoOk={true}
-                    clearable
-                    TextFieldComponent={CustomTextField}
-                  />
-                </Box>
-              </MuiPickersUtilsProvider>
-            </div>
-
-            <Box display="flex" flexDirection="column" gridGap="4px" flex="1" flexBasis="200px">
-              <PerformanceMetric label="Historical Returns" value={historicalReturns} />
-              <PerformanceMetric label="Annualized" value={annualizedReturns} />
-            </Box>
-          </Box>
-
-          <Box marginTop="12px">
-            {bullEthPnlSeries ? (
-              <HighchartsReact highcharts={Highcharts} options={chartOptions} />
-            ) : (
-              <Box display="flex" height="346px" width={1} alignItems="center" justifyContent="center">
-                <CircularProgress size={40} className={classes.loadingSpinner} />
-              </Box>
-            )}
-          </Box>
-        </>
-      ) : (
+      {isLoading ? (
         <Box display="flex" alignItems="flex-start" marginTop="8px" height="500px">
           <Box display="flex" alignItems="center" gridGap="15px">
             <CircularProgress size={15} className={classes.loadingSpinner} />
             <Typography className={classes.text}>Fetching strategy performance...</Typography>
           </Box>
         </Box>
+      ) : (
+        <StrategyPerformance strategyPnLSeries={strategyPnLSeries} tvl={tvl.toNumber()} />
       )}
     </Box>
   )
 }
 
-export default StrategyPerformance
+export default Wrapper

--- a/packages/frontend/src/components/Strategies/Crab/StrategyPerformance.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/StrategyPerformance.tsx
@@ -194,89 +194,94 @@ const StrategyPerformance: React.FC = () => {
       <Typography variant="h3" className={classes.sectionTitle}>
         Strategy Performance
       </Typography>
-      <Box display="flex" alignItems="baseline" gridColumnGap="12px" gridRowGap="4px" flexWrap="wrap">
-        <Typography
-          variant="h2"
-          className={clsx(
-            classes.heading,
-            classes.textMonospace,
-            annualizedReturns >= 0 ? classes.colorSuccess : classes.colorError,
-          )}
-        >
-          {annualizedReturns >= 0 && '+'}
-          {formatNumber(annualizedReturns)}%
-        </Typography>
+      {crabUsdPnlSeries ? (
+        <>
+          <Box display="flex" alignItems="baseline" gridColumnGap="12px" gridRowGap="4px" flexWrap="wrap">
+            <Typography
+              variant="h2"
+              className={clsx(
+                classes.heading,
+                classes.textMonospace,
+                annualizedReturns >= 0 ? classes.colorSuccess : classes.colorError,
+              )}
+            >
+              {annualizedReturns >= 0 && '+'}
+              {formatNumber(annualizedReturns)}%
+            </Typography>
 
-        <Box display="flex" alignItems="baseline" gridGap="12px">
-          <Typography className={classes.description}>Annualized USDC Return</Typography>
+            <Box display="flex" alignItems="baseline" gridGap="12px">
+              <Typography className={classes.description}>Annualized USDC Return</Typography>
 
-          <Box position="relative" top="3px">
-            <Tooltip title={<TooltipTitle />}>
-              <HelpOutlineIcon fontSize="small" className={classes.infoIcon} />
-            </Tooltip>
-          </Box>
-        </Box>
-      </Box>
-
-      <Box display="flex" gridGap="12px">
-        <Typography className={clsx(classes.description, classes.textMonospace)}>
-          {formatCurrency(tvl.toNumber(), 0)}
-        </Typography>
-        <Typography className={classes.description}>TVL</Typography>
-      </Box>
-
-      <Box display="flex" justifyContent="space-between" alignItems="flex-end" gridGap="12px" flexWrap="wrap">
-        <div>
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Box display="flex" alignItems="center" gridGap="16px" marginTop="16px">
-              <DatePicker
-                id="start-date-strategy-performance"
-                label="Start Date"
-                placeholder="MM/DD/YYYY"
-                format={'MM/dd/yyyy'}
-                value={startDate}
-                minDate={CRABV2_START_DATE}
-                onChange={(d) => setStartDate(d || new Date())}
-                animateYearScrolling={false}
-                autoOk={true}
-                clearable
-                TextFieldComponent={CustomTextField}
-              />
-
-              <Divider orientation="horizontal" className={classes.divider} />
-
-              <DatePicker
-                id="end-date-strategy-performance"
-                label="End Date"
-                placeholder="MM/DD/YYYY"
-                format={'MM/dd/yyyy'}
-                value={endDate}
-                minDate={startDate}
-                onChange={(d) => setEndDate(d || new Date())}
-                animateYearScrolling={false}
-                autoOk={true}
-                clearable
-                TextFieldComponent={CustomTextField}
-              />
+              <Box position="relative" top="3px">
+                <Tooltip title={<TooltipTitle />}>
+                  <HelpOutlineIcon fontSize="small" className={classes.infoIcon} />
+                </Tooltip>
+              </Box>
             </Box>
-          </MuiPickersUtilsProvider>
-        </div>
-
-        <Box display="flex" flexDirection="column" gridGap="4px" flex="1" flexBasis="200px">
-          <PerformanceMetric label="Historical Returns" value={historicalReturns} />
-          <PerformanceMetric label="Annualized" value={annualizedReturns} />
-        </Box>
-      </Box>
-
-      <Box marginTop="12px">
-        {crabUsdPnlSeries ? (
-          <HighchartsReact highcharts={Highcharts} options={chartOptions} />
-        ) : (
-          <Box display="flex" height="346px" width={1} alignItems="center" justifyContent="center">
-            <CircularProgress size={40} className={classes.loadingSpinner} />
           </Box>
-        )}
-      </Box>
+
+          <Box display="flex" gridGap="12px">
+            <Typography className={clsx(classes.description, classes.textMonospace)}>
+              {formatCurrency(tvl.toNumber(), 0)}
+            </Typography>
+            <Typography className={classes.description}>TVL</Typography>
+          </Box>
+
+          <Box display="flex" justifyContent="space-between" alignItems="flex-end" gridGap="12px" flexWrap="wrap">
+            <div>
+              <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                <Box display="flex" alignItems="center" gridGap="16px" marginTop="16px">
+                  <DatePicker
+                    id="start-date-strategy-performance"
+                    label="Start Date"
+                    placeholder="MM/DD/YYYY"
+                    format={'MM/dd/yyyy'}
+                    value={startDate}
+                    minDate={CRABV2_START_DATE}
+                    onChange={(d) => setStartDate(d || new Date())}
+                    animateYearScrolling={false}
+                    autoOk={true}
+                    clearable
+                    TextFieldComponent={CustomTextField}
+                  />
+
+                  <Divider orientation="horizontal" className={classes.divider} />
+
+                  <DatePicker
+                    id="end-date-strategy-performance"
+                    label="End Date"
+                    placeholder="MM/DD/YYYY"
+                    format={'MM/dd/yyyy'}
+                    value={endDate}
+                    minDate={startDate}
+                    onChange={(d) => setEndDate(d || new Date())}
+                    animateYearScrolling={false}
+                    autoOk={true}
+                    clearable
+                    TextFieldComponent={CustomTextField}
+                  />
+                </Box>
+              </MuiPickersUtilsProvider>
+            </div>
+
+            <Box display="flex" flexDirection="column" gridGap="4px" flex="1" flexBasis="200px">
+              <PerformanceMetric label="Historical Returns" value={historicalReturns} />
+              <PerformanceMetric label="Annualized" value={annualizedReturns} />
+            </Box>
+          </Box>
+
+          <Box marginTop="12px">
+            <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+          </Box>
+        </>
+      ) : (
+        <Box display="flex" alignItems="flex-start" marginTop="8px" height="500px">
+          <Box display="flex" alignItems="center" gridGap="15px">
+            <CircularProgress size={15} className={classes.loadingSpinner} />
+            <Typography className={classes.text}>Fetching strategy performance...</Typography>
+          </Box>
+        </Box>
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
# Task:

Fix show loading on strategy performance (both crab/bull) instead of 0 numbers for returns.
FIXES ENG-1259

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files