### PR TITLE
fix: show crisp chat to everyone 

### DIFF
--- a/packages/frontend/src/components/CrispChat/CrispChat.tsx
+++ b/packages/frontend/src/components/CrispChat/CrispChat.tsx
@@ -1,8 +1,6 @@
-import useToggleCrispChat from '@hooks/useToggleCrispChat'
 import { useEffect } from 'react'
 
 export function CrispChat() {
-  const { hide } = useToggleCrispChat()
   useEffect(() => {
     if (typeof window === 'undefined') return
     const windowObj: any = window
@@ -16,7 +14,6 @@ export function CrispChat() {
       s.async = 1
       d.getElementsByTagName('head')[0].appendChild(s)
     })()
-    hide()
   }, [])
   return null
 }

--- a/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/BullTrade/Deposit.tsx
@@ -36,7 +36,6 @@ import useExecuteOnce from '@hooks/useExecuteOnce'
 import useAmplitude from '@hooks/useAmplitude'
 import { useZenBullStyles } from './styles'
 import { BullTradeType, BullTransactionConfirmation } from './index'
-import useToggleCrispChat from '@hooks/useToggleCrispChat'
 
 const BullDeposit: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) => void }> = ({ onTxnConfirm }) => {
   const classes = useZenBullStyles()
@@ -118,18 +117,15 @@ const BullDeposit: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) =
       })
   }, 500)
 
-  const { show: showCrispChat } = useToggleCrispChat()
-
   const onInputChange = useCallback(
     (ethToDeposit: string) => {
-      showCrispChat()
       const depositEthBN = new BigNumber(ethToDeposit)
       depositEthBN.isGreaterThan(0) ? trackDepositAmountEnteredOnce(depositEthBN) : null
       setDepositAmount(ethToDeposit)
       depositAmountRef.current = ethToDeposit
       debouncedDepositQuote(ethToDeposit)
     },
-    [trackDepositAmountEnteredOnce, debouncedDepositQuote, showCrispChat],
+    [trackDepositAmountEnteredOnce, debouncedDepositQuote],
   )
 
   const onTxnConfirmed = useCallback(

--- a/packages/frontend/src/components/Strategies/Bull/BullTrade/Withdraw.tsx
+++ b/packages/frontend/src/components/Strategies/Bull/BullTrade/Withdraw.tsx
@@ -41,7 +41,6 @@ import useExecuteOnce from '@hooks/useExecuteOnce'
 import { useZenBullStyles } from './styles'
 import { BullTradeType, BullTransactionConfirmation } from './index'
 import useTrackTransactionFlow from '@hooks/useTrackTransactionFlow'
-import useToggleCrispChat from '@hooks/useToggleCrispChat'
 
 const BullWithdraw: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) => void }> = ({ onTxnConfirm }) => {
   const classes = useZenBullStyles()
@@ -142,11 +141,9 @@ const BullWithdraw: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) 
         if (bullToWithdraw === withdrawAmountRef.current) setQuoteLoading(false)
       })
   }, 500)
-  const { show: showCrispChat } = useToggleCrispChat()
 
   const onInputChange = useAppCallback(
     (ethToWithdraw: string) => {
-      showCrispChat()
       const withdrawEthBN = new BigNumber(ethToWithdraw)
       withdrawEthBN.isGreaterThan(0) ? trackWithdrawAmountEnteredOnce(withdrawEthBN) : null
       const _bullToWithdraw = new BigNumber(ethToWithdraw).div(bullPositionValueInEth).times(bullBalance)
@@ -154,7 +151,7 @@ const BullWithdraw: React.FC<{ onTxnConfirm: (txn: BullTransactionConfirmation) 
       withdrawAmountRef.current = _bullToWithdraw.toString()
       debouncedWithdrawQuote(_bullToWithdraw.toString())
     },
-    [trackWithdrawAmountEnteredOnce, debouncedWithdrawQuote, bullBalance, bullPositionValueInEth, showCrispChat],
+    [trackWithdrawAmountEnteredOnce, debouncedWithdrawQuote, bullBalance, bullPositionValueInEth],
   )
 
   const onTxnConfirmed = useCallback(

--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
@@ -58,7 +58,6 @@ import { CRAB_EVENTS } from '@utils/amplitude'
 import useAmplitude from '@hooks/useAmplitude'
 import useExecuteOnce from '@hooks/useExecuteOnce'
 import useTrackTransactionFlow from '@hooks/useTrackTransactionFlow'
-import useToggleCrispChat from '@hooks/useToggleCrispChat'
 
 type CrabDepositProps = {
   onTxnConfirm: (txn: CrabTransactionConfirmation) => void
@@ -137,16 +136,14 @@ const CrabDeposit: React.FC<CrabDepositProps> = ({ onTxnConfirm }) => {
 
   const [trackDepositAmountEnteredOnce, resetTracking] = useExecuteOnce(trackUserEnteredDepositAmount)
   const logAndRunTransaction = useTrackTransactionFlow()
-  const { show: showCrispChat } = useToggleCrispChat()
 
   const onInputChange = useCallback(
     (amount: string) => {
-      showCrispChat()
       setDepositAmount(amount)
       const deposit = new BigNumber(amount)
       deposit.isGreaterThan(0) ? trackDepositAmountEnteredOnce(deposit) : null
     },
-    [setDepositAmount, trackDepositAmountEnteredOnce, showCrispChat],
+    [setDepositAmount, trackDepositAmountEnteredOnce],
   )
 
   const depositedAmount = vault?.collateralAmount ?? BIG_ZERO

--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Withdraw.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Withdraw.tsx
@@ -74,7 +74,6 @@ import useExecuteOnce from '@hooks/useExecuteOnce'
 import useAppEffect from '@hooks/useAppEffect'
 import { CrabStrategyV2TxType, CrabStrategyTxType } from 'src/types'
 import useTrackTransactionFlow from '@hooks/useTrackTransactionFlow'
-import useToggleCrispChat from '@hooks/useToggleCrispChat'
 
 enum WithdrawSteps {
   APPROVE = 'Approve CRAB',
@@ -160,16 +159,14 @@ const CrabWithdraw: React.FC<{ onTxnConfirm: (txn: CrabTransactionConfirmation) 
     [track],
   )
   const [trackWithdrawAmountEnteredOnce, resetTracking] = useExecuteOnce(trackUserEnteredWithdrawAmount)
-  const { show: showCrispChat } = useToggleCrispChat()
 
   const onInputChange = useCallback(
     (amount: string) => {
-      showCrispChat()
       setWithdrawAmount(amount)
       const withdraw = new BigNumber(amount)
       withdraw.isGreaterThan(0) ? trackWithdrawAmountEnteredOnce(withdraw) : null
     },
-    [setWithdrawAmount, trackWithdrawAmountEnteredOnce, showCrispChat],
+    [setWithdrawAmount, trackWithdrawAmountEnteredOnce],
   )
 
   const recordAnalytics = useCallback(


### PR DESCRIPTION
# Task:

fix: show crisp chat to everyone and show the offline message to users if they respond offline.

![image](https://user-images.githubusercontent.com/52928941/211493752-6d2135b5-1931-439a-9b35-38b12a50a58b.png)


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files