### PR TITLE
fix: fix MetricLabel's fontsize

### DIFF
--- a/packages/frontend/src/components/Metric.tsx
+++ b/packages/frontend/src/components/Metric.tsx
@@ -69,19 +69,25 @@ const useLabelStyles = makeStyles((theme) =>
       color: 'rgba(255, 255, 255, 0.5)',
     },
     label: {
-      fontSize: '15px',
+      fontSize: (props: StyleProps): string => (props.isSmall ? '14px' : '15px'),
       fontWeight: 500,
       width: 'max-content',
     },
     infoIcon: {
-      fontSize: '15px',
+      fontSize: (props: StyleProps): string => (props.isSmall ? '14px' : '15px'),
       marginLeft: theme.spacing(0.5),
     },
   }),
 )
 
-export const MetricLabel: React.FC<{ label: string; tooltipTitle?: string }> = ({ label, tooltipTitle }) => {
-  const classes = useLabelStyles()
+interface MetricLabelProps {
+  label: string
+  tooltipTitle?: string
+  isSmall?: boolean
+}
+
+export const MetricLabel: React.FC<MetricLabelProps> = ({ label, tooltipTitle, isSmall = false }) => {
+  const classes = useLabelStyles({ isSmall })
 
   return (
     <div className={classes.labelContainer}>

--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Deposit.tsx
@@ -490,15 +490,16 @@ const CrabDeposit: React.FC<CrabDepositProps> = ({ onTxnConfirm }) => {
 
             <Box display="flex" alignItems="center" gridGap="6px" flex="1">
               <Metric
+                isSmall
                 label={
                   <MetricLabel
+                    isSmall
                     label={useQueue ? 'Est. Price Impact' : 'Price Impact'}
                     tooltipTitle={useQueue ? 'Average price impact based on historical standard deposits' : undefined}
                   />
                 }
                 value={formatNumber(depositPriceImpactNumber) + '%'}
                 textColor={depositPriceImpactNumber > 3 ? 'error' : undefined}
-                isSmall
                 flexDirection="row"
                 justifyContent="space-between"
                 gridGap="8px"

--- a/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Withdraw.tsx
+++ b/packages/frontend/src/components/Strategies/Crab/CrabTradeV2/Withdraw.tsx
@@ -607,8 +607,10 @@ const CrabWithdraw: React.FC<{ onTxnConfirm: (txn: CrabTransactionConfirmation) 
 
             <Box display="flex" alignItems="center" gridGap="6px" flex="1">
               <Metric
+                isSmall
                 label={
                   <MetricLabel
+                    isSmall
                     label={useQueue ? 'Est. Price Impact' : 'Price Impact'}
                     tooltipTitle={
                       useQueue
@@ -621,7 +623,6 @@ const CrabWithdraw: React.FC<{ onTxnConfirm: (txn: CrabTransactionConfirmation) 
                 }
                 value={formatNumber(withdrawPriceImpactNumber) + '%'}
                 textColor={withdrawPriceImpactNumber > 3 ? 'error' : undefined}
-                isSmall
                 flexDirection="row"
                 justifyContent="space-between"
                 gridGap="8px"

--- a/packages/frontend/src/components/Trade/Mint.tsx
+++ b/packages/frontend/src/components/Trade/Mint.tsx
@@ -261,16 +261,20 @@ const MintSqueeth: React.FC<MintProps> = ({ onMint, showManageLink }) => {
         flexWrap="wrap"
       >
         <Metric
+          isSmall
           label={
-            <MetricLabel label="Liquidation Price" tooltipTitle={`${Tooltips.LiquidationPrice}. ${Tooltips.Twap}`} />
+            <MetricLabel
+              isSmall
+              label="Liquidation Price"
+              tooltipTitle={`${Tooltips.LiquidationPrice}. ${Tooltips.Twap}`}
+            />
           }
           value={formatCurrency(liqPrice.toNumber())}
-          isSmall
         />
         <Metric
-          label={<MetricLabel label="Current collateral ratio" tooltipTitle={Tooltips.CurrentCollRatio} />}
-          value={formatNumber(existingCollatPercent) + '%'}
           isSmall
+          label={<MetricLabel isSmall label="Current collateral ratio" tooltipTitle={Tooltips.CurrentCollRatio} />}
+          value={formatNumber(existingCollatPercent) + '%'}
         />
       </Box>
 


### PR DESCRIPTION
# Task:

fix MetricLabel's fontsize

## Description

As a result of incorrect size, the selected metric label's don't look aligned. "Price Impact" is slightly bigger than "Uniswap Fee".

### Before
<img width="1471" alt="before" src="https://user-images.githubusercontent.com/12045121/216396696-036d3e1f-b2f1-4ac1-90c2-1449698574bf.png">

### After
<img width="1484" alt="after" src="https://user-images.githubusercontent.com/12045121/216396737-6c1eb5e6-1f99-4473-9a33-7e507868c404.png">


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files