### PR TITLE
fix: add server side redirect for /strategies

### DIFF
--- a/packages/frontend/pages/strategies/index.tsx
+++ b/packages/frontend/pages/strategies/index.tsx
@@ -14,3 +14,12 @@ const Redirection = () => {
 const Page: React.FC = () => <Redirection />
 
 export default Page
+
+export async function getServerSideProps() {
+  return {
+    redirect: {
+      destination: '/strategies/crab',
+      permanent: true,
+    },
+  }
+}


### PR DESCRIPTION
# Task:

**/strategies** was showing nothing when opened directly via the link. only client side was working.

## Description

Fixes ENG-1447

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files