### PR TITLE
fix: preserve query params with server side redirect

### DIFF
--- a/packages/frontend/pages/strategies/index.tsx
+++ b/packages/frontend/pages/strategies/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { GetServerSideProps } from 'next'
 
 const Redirection = () => {
   const router = useRouter()
@@ -15,10 +16,12 @@ const Page: React.FC = () => <Redirection />
 
 export default Page
 
-export async function getServerSideProps() {
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  const queryParams = new URLSearchParams(query as Record<string, string>)
+
   return {
     redirect: {
-      destination: '/strategies/crab',
+      destination: `/strategies/crab?${queryParams.toString()}`,
       permanent: true,
     },
   }


### PR DESCRIPTION
# Task:
preserve query params with server side redirect


## Description
required for preserving UTM data when the user lands on `/strategies` route

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files