### PR TITLE
fix: foundry fuzz config

### DIFF
--- a/packages/zen-bull-netting/foundry.toml
+++ b/packages/zen-bull-netting/foundry.toml
@@ -14,8 +14,7 @@ gas_reports = ["ZenBullNetting"]
 
 [profile.fuzz]
 runs = 2500
-max_local_rejects = 1024
-max_global_rejects = 65536
+max_test_rejects = 65536
 seed = '0x3e8'
 dictionary_weight = 40
 include_storage = true

--- a/packages/zen-bull-vault/foundry.toml
+++ b/packages/zen-bull-vault/foundry.toml
@@ -14,8 +14,7 @@ gas_reports = ["ZenBullStrategy", "FlashZen"]
 
 [profile.fuzz]
 runs = 2000
-max_local_rejects = 1024
-max_global_rejects = 65536
+max_test_rejects = 65536
 seed = '0x3e8'
 dictionary_weight = 40
 include_storage = true


### PR DESCRIPTION
# Task:

## Description

foundry config option `fuzz.max_local_rejects` was removed and `fuzz.max_global_rejects` was deprecated and replaced by `fuzz.max_test_rejects`

refs
issue: https://github.com/foundry-rs/foundry/issues/3153
pr: https://github.com/foundry-rs/foundry/pull/4466

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files