### PR TITLE
fix: get the correct client ip from cloudflare reverse proxy

### DIFF
--- a/packages/frontend/middleware.ts
+++ b/packages/frontend/middleware.ts
@@ -11,12 +11,7 @@ export async function middleware(request: NextRequest) {
   const country = cloudflareCountry ?? request.geo?.country
   const url = request.nextUrl
 
-  const ip = request.headers.get('x-forwarded-for') ?? request.ip
-  console.log('ip', ip, request.headers.get('x-forwarded-for'), request.ip)
-  console.log('cf ip', request.headers.get('cf-connecting-ip'), request.headers.get('true-client-ip'))
-  console.log(request.headers)
-  // const ip = "212.103.61.75"
-
+  const ip = request.headers.get('cf-connecting-ip')
 
   if (ip) {
     const redisData = await redis.get(ip)


### PR DESCRIPTION
# Task: Cloudfare is a reverse proxy, and hence the request.ip was giving cloudflares ip and not the clients. I have fixed it to get the connecting ip set by cloudflare

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes (linear-task)

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files