### PR TITLE
if ipqs does not say vpn, then dont check again

### DIFF
--- a/packages/frontend/middleware.ts
+++ b/packages/frontend/middleware.ts
@@ -31,7 +31,6 @@ export async function middleware(request: NextRequest) {
       }
     } else if (redisData == null) {
       // check vpn from ipqs if redisData does not exist
-      console.log('calling ipqs')
       const isFromVpn = await isVPN(ip)
       console.log('vpnip', ip, isFromVpn)
       if (isFromVpn) {


### PR DESCRIPTION
If we have too many requests to ipqs, then lets cache the positive responses also.

downside, the positive ips might later become VPNs and we might not catch them

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Testing code
- [ ] Document update or config files