### PR TITLE
reduce cache expiry time to 3 days

### DIFF
--- a/packages/frontend/middleware.ts
+++ b/packages/frontend/middleware.ts
@@ -9,7 +9,7 @@ const redis = new Redis({
   token: process.env.UPSTASH_REDIS_REST_TOKEN!,
 })
 
-const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000
+const THREE_DAYS_IN_MS = 3 * 24 * 60 * 60 * 1000
 
 interface RedisResponse {
   value: string
@@ -28,8 +28,8 @@ async function isIPBlockedInRedis(ip: string, currentTime: number) {
   if (redisData) {
     try {
       const { value, timestamp } = redisData
-      // check if entry is valid and is less than 30 days old
-      if (value === BLOCKED_IP_VALUE && currentTime - timestamp <= THIRTY_DAYS_IN_MS) {
+      // check if entry is valid and is not more than 3 days old
+      if (value === BLOCKED_IP_VALUE && currentTime - timestamp <= THREE_DAYS_IN_MS) {
         isIPBlocked = true
       }
     } catch (error) {


### PR DESCRIPTION
# Task:

Reduce cache expiry time from 30 days to 3 days


## Description

Originally, the setting was for 30 days, indicating that when a data center is whitelisted, existing users would only gain access to the site after 30 days from their initial visit. However, a 3-day period seems to be an optimal balance, reducing the frequency of API calls while also avoiding issues with outdated data.

Fixes ENG-2043

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files